### PR TITLE
Adds  #'sum to API

### DIFF
--- a/src/main/clojure/core/matrix.clj
+++ b/src/main/clojure/core/matrix.clj
@@ -442,7 +442,12 @@
 (defn length-squared
   "Calculates the squared length (squared magnitude) of a vector"
   ([m]
-    (mp/length-squared m)))
+     (mp/length-squared m)))
+
+(defn sum
+  "Calculates the sum of all the elements"
+  [m]
+  (mp/sum m))
 
 ;; create all unary maths operators
 (eval

--- a/src/main/clojure/core/matrix.clj
+++ b/src/main/clojure/core/matrix.clj
@@ -71,7 +71,7 @@
   "Constructs a new zero-filled vector with the given length"
   ([length]
     (if-let [m (current-implementation-object)]
-      (mp/new-vector m length) 
+      (mp/new-vector m length)
       (error "No core.matrix implementation available")))
   ([length implementation]
     (mp/new-vector (imp/get-canonical-object implementation) length)))
@@ -109,7 +109,7 @@
       (error "No core.matrix implementation available")))
   ([implementation data]
     (mp/construct-matrix (imp/get-canonical-object implementation) (map vector data))))
-  
+
 (defn identity-matrix
   "Constructs a 2D identity matrix with the given number or rows"
   ([dims]
@@ -129,8 +129,8 @@
 ;; ======================================
 ;; matrix assignment and copying
 
-(defn assign! 
-  "Assigns a value to a matrix. 
+(defn assign!
+  "Assigns a value to a matrix.
    Returns the mutated matrix"
   ([m a]
     (mp/assign! m a)
@@ -149,7 +149,7 @@
     (mp/clone m)))
 
 (defn to-nested-vectors
-  "Converts an array to nested vectors. 
+  "Converts an array to nested vectors.
    The depth of nesting is equal to the dimensionality of the array."
   ([m]
     (mp/convert-to-nested-vectors m)))
@@ -220,7 +220,7 @@
 (defn shape
   "Returns the shape of a matrix, i.e. the dimension sizes for all dimensions.
 
-   Result may be a sequence or Java array, to allow implemenations flexibility to return 
+   Result may be a sequence or Java array, to allow implemenations flexibility to return
    their own internal representation of matrix shape.
 
    You are guaranteed however that you can call `seq` on this to get a sequence of dimension sizes."
@@ -232,7 +232,7 @@
   ([m]
     (and (satisfies? mp/PIndexedSetting m) (mp/is-mutable? m))))
 
-(defn supports-dimensionality? 
+(defn supports-dimensionality?
   "Returns true if the implementation for a given matrix supports a specific dimensionality, i.e.
    can create an manipulate matrices with the given number of dimensions"
   ([m dimension-count]
@@ -281,7 +281,7 @@
     (mp/get-column m y)))
 
 (defn coerce
-  "Coerces param to a format usable by a specific matrix implementation. 
+  "Coerces param to a format usable by a specific matrix implementation.
    If param is already in a format deemed useable by the implementation, returns it unchanged."
   ([m param]
     (or
@@ -536,12 +536,12 @@
     (vector-dot [a b] (* a b))
     (length [a] (double a))
     (length-squared [a] (Math/sqrt (double a)))
-    (normalise [a] 
-      (let [a (double a)] 
-        (cond 
+    (normalise [a]
+      (let [a (double a)]
+        (cond
           (> a 0.0) 1.0
           (< a 0.0) -1.0
-          :else 0.0))) 
+          :else 0.0)))
   java.lang.Object
     (vector-dot [a b])
     (length [a]
@@ -559,38 +559,38 @@
 
 (extend-protocol mp/PAssignment
   java.lang.Object
-    (assign! [m x] 
-      (cond 
+    (assign! [m x]
+      (cond
         (mp/is-vector? x)
           (dotimes [i (row-count m)]
             (mset! m i (mget x i)))
         (array? x)
-          (doall (map (fn [a b] (mp/assign! a b)) 
-                      (slices m) 
+          (doall (map (fn [a b] (mp/assign! a b))
+                      (slices m)
                       (slices x)))
         (.isArray (class x))
           (mp/assign-array! m x)
-        :else 
+        :else
           (error "Can't assign to a non-matrix object: " (class m))))
-    (assign-array! 
-      ([m arr] 
+    (assign-array!
+      ([m arr]
 	      (let [alen (long (count arr))]
 	        (if (mp/is-vector? m)
 	          (dotimes [i alen]
 	            (mp/set-1d m i (nth arr i)))
 	          (mp/assign-array! m arr 0 alen))))
-      ([m arr start length] 
+      ([m arr start length]
 	      (if (mp/is-vector? m)
 	          (dotimes [i (long length)]
 	            (mp/set-1d m i (nth arr i)))
 	          (let [ss (seq (slices m))
 	                skip (long (if ss (ecount (first (slices m))) 0))]
-	            (doseq-indexed [s ss i] 
+	            (doseq-indexed [s ss i]
 	              (mp/assign-array! s arr (* skip i) skip)))))))
 
 (extend-protocol mp/PMatrixCloning
 	  java.lang.Cloneable
-	    (clone [m] 
+	    (clone [m]
 	      (.invoke ^java.lang.reflect.Method (.getDeclaredMethod (class m) "clone" nil) m nil))
 	  java.lang.Object
 	    (clone [m]
@@ -615,7 +615,7 @@
     (is-scalar? [m] false)
     (get-shape [m] (for [i (range (mp/dimensionality m))] (mp/dimension-count m i)))
     (dimension-count [m i] (error "Can't determine count of dimension " i " on Object: " (class m))))
-    
+
 
 ;; generic versions of matrix ops
 (extend-protocol mp/PMatrixOps
@@ -646,7 +646,7 @@
     (element-multiply [m a]
       (clojure.core/* m a))
     (matrix-multiply [m a]
-      (cond 
+      (cond
         (number? a) (* m a)
         (matrix? a) (mp/pre-scale a m)
         :else (error "Don't know how to multiply number with: " (class a))))
@@ -663,7 +663,7 @@
       (assign! a (m a)))
   java.lang.Object
     (vector-transform [m a]
-      (cond 
+      (cond
         (matrix? m) (mul m a)
         :else (error "Don't know how to transform using: " (class m))))
     (vector-transform! [m a]
@@ -719,7 +719,7 @@
       (== a b))
   java.lang.Object
     (matrix-equals [a b]
-      (not (some false? (map == (mp/element-seq a) (mp/element-seq b)))))) 
+      (not (some false? (map == (mp/element-seq a) (mp/element-seq b))))))
 
 ;; functional operations
 (extend-protocol mp/PFunctionalOperations
@@ -747,7 +747,7 @@
         (f init m)))
   java.lang.Object
     (element-seq [m]
-      (cond 
+      (cond
         (matrix? m) (mapcat mp/element-seq (slices m))
         :else (seq m)))
     (element-map
@@ -771,11 +771,11 @@
         (coerce m (mp/element-reduce (mp/convert-to-nested-vectors m) f init))))
   nil
     (element-seq [m] nil)
-    (element-map 
+    (element-map
       ([m f] nil)
       ([m f a] nil)
       ([m f a more] nil))
-    (element-map! 
+    (element-map!
       ([m f] nil)
       ([m f a] nil)
       ([m f a more] nil))
@@ -791,17 +791,17 @@
       m)
   java.lang.Object
     (convert-to-nested-vectors [m]
-      (cond 
+      (cond
         (scalar? m) m
-        (mp/is-vector? m) 
+        (mp/is-vector? m)
           (mapv #(mget m %) (range (row-count m)))
-        (matrix? m) 
+        (matrix? m)
           (mapv mp/convert-to-nested-vectors (slices m))
-        (sequential? m) 
+        (sequential? m)
           (mapv mp/convert-to-nested-vectors m)
-        (seq? m) 
+        (seq? m)
           (mapv mp/convert-to-nested-vectors m)
-        :default 
+        :default
           (error "Can't work out how to convert to nested vectors: " (class m) " = " m))))
 
 (extend-protocol mp/PCoercion
@@ -836,9 +836,9 @@
 
 (extend-protocol mp/PSpecialisedConstructors
   java.lang.Object
-    (identity-matrix [m dims] 
+    (identity-matrix [m dims]
       (diagonal-matrix (repeat dims 1.0)))
-    (diagonal-matrix [m diagonal-values] 
+    (diagonal-matrix [m diagonal-values]
       (let [dims (count diagonal-values)
             diagonal-values (coerce [] diagonal-values)
             zs (vec (repeat dims 0.0))
@@ -865,7 +865,6 @@
 
 (defn set-current-implementation
   "Sets the currently active matrix implementation"
-  ([m] 
-    (alter-var-root (var core.matrix/*matrix-implementation*) 
+  ([m]
+    (alter-var-root (var core.matrix/*matrix-implementation*)
                     (fn [_] (imp/get-implementation-key m)))))
-

--- a/src/main/clojure/core/matrix/impl/persistent_vector.clj
+++ b/src/main/clojure/core/matrix/impl/persistent_vector.clj
@@ -52,17 +52,17 @@
     (instance? java.util.List x) (coerce-nested x)
     (instance? java.lang.Iterable x) (coerce-nested x)
     (.isArray (class x)) (vec (seq x))
-    :default (error "Can't coerce to vector: " (class x)))) 
+    :default (error "Can't coerce to vector: " (class x))))
 
 (defn vector-dimensionality ^long [m]
   "Calculates the dimensionality (== nesting depth) of nested persistent vectors"
   (cond
-    (clojure.core/vector? m) 
-      (if (> (count m) 0) 
-        (+ 1 (vector-dimensionality (m 0))) 
+    (clojure.core/vector? m)
+      (if (> (count m) 0)
+        (+ 1 (vector-dimensionality (m 0)))
         1)
     (mp/is-scalar? m) 0
-    :else (long (mp/dimensionality m)))) 
+    :else (long (mp/dimensionality m))))
 
 ;; =======================================================================
 ;; Implementation for nested Clojure persistent vectors used as matrices
@@ -73,15 +73,15 @@
     (implementation-key [m] :persistent-vector)
     (new-vector [m length] (vec (repeat length 0.0)))
     (new-matrix [m rows columns] (vec (repeat rows (mp/new-vector m columns))))
-    (new-matrix-nd [m dims] 
-      (if-let [dims (seq dims)] 
+    (new-matrix-nd [m dims]
+      (if-let [dims (seq dims)]
         (vec (repeat (first dims) (mp/new-matrix-nd m (next dims))))
         0.0))
     (construct-matrix [m data]
-      (cond 
-        (mp/is-scalar? data) 
+      (cond
+        (mp/is-scalar? data)
           data
-        (>= (mp/dimensionality data) 1) 
+        (>= (mp/dimensionality data) 1)
           (mapv #(mp/construct-matrix m %) (for [i (range (mp/dimension-count data 0))] (mp/get-major-slice data i)))
         (sequential? data)
           (mapv #(mp/construct-matrix m %) data)
@@ -106,9 +106,9 @@
 ;; we extend this so that nested mutable implemenations are possible
 (extend-protocol mp/PIndexedSetting
   clojure.lang.IPersistentVector
-    (set-1d [m row v] 
+    (set-1d [m row v]
       (error "Persistent vectors are not mutable!"))
-    (set-2d [m row column v] 
+    (set-2d [m row column v]
       (mp/set-1d (m 0) column v))
     (set-nd [m indexes v]
       (if-let [ixs (seq indexes)]
@@ -117,7 +117,7 @@
           (error "Persistent vectors are not mutable!"))
         (error "Trying to set on a persistent vector with insufficient indexes?")))
     (is-mutable? [m]
-      (if (vector-1d? m) 
+      (if (vector-1d? m)
         false
         (mp/is-mutable? (m 0)))))
 
@@ -171,7 +171,7 @@
     (matrix-multiply [m a]
       (let [mdims (long (mp/dimensionality m))
             adims (long (mp/dimensionality a))]
-        (cond 
+        (cond
           (and (== mdims 1) (== adims 2))
             (vec (for [i (range (mp/dimension-count a 1))]
 	                 (let [r (mp/get-column a i)]
@@ -230,9 +230,9 @@
       false)
     (get-shape [m]
       (let [c (.length m)]
-        (cons c (if (> c 0) 
+        (cons c (if (> c 0)
                   (mp/get-shape (m 0))
-                  nil)))) 
+                  nil))))
     (dimension-count [m x]
       (if (== x 0)
         (.length m)
@@ -251,7 +251,7 @@
         (apply mapmatrix f m a more)))
     (element-map!
       ([m f]
-        (if (vector-1d? m) 
+        (if (vector-1d? m)
           (error "Persistent vector matrices are not mutable!")
           (doseq [s m] (mp/element-map! s f))))
       ([m f a]

--- a/src/main/clojure/core/matrix/impl/persistent_vector.clj
+++ b/src/main/clojure/core/matrix/impl/persistent_vector.clj
@@ -154,6 +154,11 @@
     (normalise [a]
       (mp/scale a (/ 1.0 (Math/sqrt (mp/length-squared a))))))
 
+(extend-protocol mp/PSummable
+  clojure.lang.IPersistentVector
+    (sum [a]
+      (mp/element-reduce a +)))
+
 (extend-protocol mp/PCoercion
   clojure.lang.IPersistentVector
     (coerce-param [m param]

--- a/src/main/clojure/core/matrix/protocols.clj
+++ b/src/main/clojure/core/matrix/protocols.clj
@@ -18,16 +18,16 @@
 ;; ===================================================================================
 ;; MANDATORY PROTOCOLS FOR ALL IMPLEMENTATIONS
 ;;
-;; A compliant core.matrix implementation must implement these. 
+;; A compliant core.matrix implementation must implement these.
 ;; Otherwise things will fail.
 
 (defprotocol PImplementation
   "Protocol for general implementation functionality"
   (implementation-key [m]
-    "Returns a keyword representing this implementation. 
+    "Returns a keyword representing this implementation.
      Each implementation should have one unique key.")
   (construct-matrix [m data]
-    "Returns a new matrix containing the given data. Data should be in the form of either 
+    "Returns a new matrix containing the given data. Data should be in the form of either
      nested sequences or a valid existing matrix")
   (new-vector [m length]
     "Returns a new vector (1D column matrix) of the given length.")
@@ -40,17 +40,17 @@
     "Returns true if the implementation supports matrices with the given number of dimensions."))
 
 (defprotocol PDimensionInfo
-  "Protocol to return standard dimension information about a matrix. 
+  "Protocol to return standard dimension information about a matrix.
    dimensionality and dimension-count are mandatory for implementations"
-  (dimensionality [m] 
+  (dimensionality [m]
     "Returns the number of dimensions of a matrix")
   (get-shape [m]
-    "Returns the shape of the matrix, as an array or sequence of dimension sizes") 
-  (is-scalar? [m] 
+    "Returns the shape of the matrix, as an array or sequence of dimension sizes")
+  (is-scalar? [m]
     "Tests whether an object is a scalar value")
-  (is-vector? [m] 
+  (is-vector? [m]
     "Tests whether an object is a vector (1D matrix)")
-  (dimension-count [m dimension-number] 
+  (dimension-count [m dimension-number]
     "Returns the size of a specific dimension "))
 
 ;; protocol arity overloads behave oddly, so different names used for simplicity
@@ -64,11 +64,11 @@
 ;; ===================================================================================
 ;; MANDATORY PROTOCOLS FOR MUTABLE MATRICES
 ;;
-;; A compliant core.matrix mutable implementation must implement these. 
+;; A compliant core.matrix mutable implementation must implement these.
 ;; Otherwise things will fail.
 
 (defprotocol PIndexedSetting
-  "Protocol for indexed setter access to matrices and vectors. 
+  "Protocol for indexed setter access to matrices and vectors.
    Must be supported for any mutable matrix type."
   (set-1d [m row v])
   (set-2d [m row column v])
@@ -77,13 +77,13 @@
 
 (defprotocol PMatrixCloning
   "Protocol for cloining a matrix value."
-  (clone [m] "Returns a clone of a matrix value. Must be a new independent (non-view) 
+  (clone [m] "Returns a clone of a matrix value. Must be a new independent (non-view)
               instance if the matrix is mutable."))
 
 
 ;; ===================================================================================
 ;; OPTTIONAL PROTOCOLS
-;; 
+;;
 ;; implementations don't need to provide these since fallback default implementations
 ;; are provided. However, they should consider doing so for performance reasons
 
@@ -94,9 +94,9 @@
   (diagonal-matrix [m diagonal-values] "Create a diagonal matrix with the specified leading diagonal values"))
 
 (defprotocol PCoercion
-  "Protocol to coerce a parameter to a format usable by a specific implementation. It is 
+  "Protocol to coerce a parameter to a format usable by a specific implementation. It is
    up to the implementation to determine what parameter types they support. If the
-   implementation is unable to perform coercion, it may return nil." 
+   implementation is unable to perform coercion, it may return nil."
   (coerce-param [m param]
     "Attempts to coerce param into a matrix format supported by the implementation of matrix m.
      May return nil if unable to do so, in which case a default implementation can be used."))
@@ -108,7 +108,7 @@
 (defprotocol PAssignment
   "Protocol for assigning values to mutable matrices."
   (assign! [m source] "Sets all the values in a matrix from a matrix source")
-  (assign-array! 
+  (assign-array!
     [m arr]
     [m arr start length]))
 
@@ -118,7 +118,7 @@
   (element-multiply [m a]))
 
 (defprotocol PVectorTransform
-  "Protocol to support transformation of a vector to another vector. 
+  "Protocol to support transformation of a vector to another vector.
    Is equivalent to matrix multiplication when 2D matrices are used as transformations.
    But other transformations are possible, e.g. affine transformations."
   (vector-transform [m v] "Transforms a vector")
@@ -147,7 +147,7 @@
   (normalise [a]))
 
 (defprotocol PMutableVectorOps
-  (normalise! [a])) 
+  (normalise! [a]))
 
 (defprotocol PMatrixOps
   "Protocol to support common matrix operations"
@@ -156,6 +156,10 @@
   (inverse [m])
   (negate [m])
   (transpose [m]))
+
+(defprotocol PSummable
+  "Protocol to support the summing of all elements in a matrix or vector."
+  (sum [m]))
 
 ;; code generation for protocol with unary mathematics operations defined in c.m.i.mathsops namespace
 ;; also generate in-place versions e.g. signum!
@@ -173,7 +177,7 @@
   (get-slice [m dimension i]))
 
 (defprotocol PMatrixSubComponents
-  (main-diagonal [m])) 
+  (main-diagonal [m]))
 
 
 (defprotocol PFunctionalOperations

--- a/src/test/clojure/core/matrix/test_persistent_vector_implementation.clj
+++ b/src/test/clojure/core/matrix/test_persistent_vector_implementation.clj
@@ -56,7 +56,12 @@
       (is (equals [3 7] (mul m [1 1])))
       (is (equals [2 4] (get-column m 1))))))
 
+(deftest test-sum
+  (testing "summing"
+    (is (= 2.0 (sum [[1.0 0.0] [0.0 1.0]])))
+    (is (= 1.5 (sum [1.0 0.5])))))
+
 ;; run complicance tests
 
 (deftest compliance-test
-  (core.matrix.compliance-tester/compliance-test [])) 
+  (core.matrix.compliance-tester/compliance-test []))

--- a/src/test/clojure/core/matrix/test_persistent_vector_implementation.clj
+++ b/src/test/clojure/core/matrix/test_persistent_vector_implementation.clj
@@ -18,7 +18,7 @@
       (.add al 3.0)
       (is (= [1.0 2.0 3.0] (coerce [] al)))
       (is (== 1.0 (mget al 0)))))
-  
+
   (testing "trace"
     (is (== 5 (trace [[1 2] [3 4]])))))
 


### PR DESCRIPTION
In order to flesh out the API more I'm using it to implement some common machine learning metrics.  The first hiccup I ran into was that `sum` was not part of the API.  I added it along with the corresponding protocol and default implementation for the persistent vector.

I did consider just making a single implementation as `(m/ereduce m/add m)` defined in `core.clj` but I didn't know if that would be appropriate for all matrix types.  It seems like it would though so I could revert these changes and go with that instead.  What do you think?

BTW, any chance I could convince you to drop clojure.test and use midje instead?  Midje tests are far easier to read and write IMO and double as a nice form of documentation.
