### PR TITLE
#40 Add elementary row operations

### DIFF
--- a/src/main/clojure/clojure/core/matrix.clj
+++ b/src/main/clojure/clojure/core/matrix.clj
@@ -806,6 +806,25 @@
                 ~'m))) mops/maths-ops))
        )
 
+;; ==================================
+;; Elementary row operations
+;;
+
+(defn swap-rows
+  "Swap row i with row j"
+  [X i j]
+  (mp/swap-rows X i j))
+
+(defn multiply-row
+  "Multiply row i by constant k"
+  [X i k]
+  (mp/multiply-rows X i k))
+
+(defn add-row
+  "Add a row j times constant k to a row i and replace i"
+  [X i j k]
+  (mp/add-row X i j k))
+
 ;; ===================================
 ;; Linear algebra algorithms
 ;;
@@ -1007,3 +1026,4 @@
   ([m]
     (alter-var-root (var clojure.core.matrix/*matrix-implementation*)
                     (fn [_] (imp/get-implementation-key m)))))
+

--- a/src/main/clojure/clojure/core/matrix.clj
+++ b/src/main/clojure/clojure/core/matrix.clj
@@ -818,7 +818,7 @@
 (defn multiply-row
   "Multiply row i by constant k"
   [X i k]
-  (mp/multiply-rows X i k))
+  (mp/multiply-row X i k))
 
 (defn add-row
   "Add a row j times constant k to a row i and replace i"

--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -551,6 +551,18 @@
       (double-array (mp/element-seq m)))
     (as-double-array [m] nil)) 
 
+;; row operations
+(extend-protocol mp/PRowOperations
+  java.lang.Object
+    (swap-rows [X i j]
+      ())
+  java.lang.Object
+    (multiply-row [X i k]
+      ())
+  java.lang.Object
+    (add-row [X i j k]
+      ()))
+
 ;; functional operations
 (extend-protocol mp/PFunctionalOperations
   java.lang.Number

--- a/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
@@ -274,6 +274,18 @@
     (pre-scale [m a]
       (mapmatrix (partial * a) m)))
 
+(extend-protocol mp/PRowOperations
+  clojure.lang.IPersistentVector
+    (swap-rows [X i j]
+      (assoc X j (X i) i (X j)))
+    clojure.lang.IPersistentVector
+    (multiply-row [X i k]
+      (require 'clojure.core.matrix)
+      (assoc X i (clojure.core.matrix/e* k (X i))))
+    clojure.lang.IPersistentVector
+    (add-row [X i j k]
+      (assoc X i (+ X i) (* k (X j)))))
+
 ;; helper functin to build generic maths operations
 (defn build-maths-function
   ([[name func]]

--- a/src/main/clojure/clojure/core/matrix/protocols.clj
+++ b/src/main/clojure/clojure/core/matrix/protocols.clj
@@ -409,6 +409,20 @@
    provide their own implementation."
   (element-pow [m exponent])) 
 
+;; ==================================
+;; Elementary Row Operation Protocols
+;;
+
+(defprotocol PRowOperations
+  "Protocol for elementary row operations"
+  (swap-rows [X i j]
+    "Returns a new matrix with rows i and j swapped")
+  (multiply-row [X i k]
+    "Returns a new matrix with row i multiplied by k")
+  (add-row [X i j k]
+    "Returns a new matrix with row i added to row j times k"))
+
+
 ;; code generation for protocol with unary mathematics operations defined in c.m.i.mathsops namespace
 ;; also generate in-place versions e.g. signum!
 (eval

--- a/src/main/clojure/clojure/core/matrix/row_operators.clj
+++ b/src/main/clojure/clojure/core/matrix/row_operators.clj
@@ -1,0 +1,15 @@
+(defn swap 
+  "Swap row i with row j"
+  [X i j] 
+  (assoc X j (X i) i (X j)))
+
+(defn multiply
+  "Multiply row i by constant k"
+  [X i k]
+  (assoc X i (* k (X i))))
+
+(defn add
+  "Add a row j times a constant k to a row i and replace i"
+  [X i j k]
+  (assoc X i (+ (X i) (* k (X j)))))
+

--- a/src/main/clojure/clojure/core/matrix/row_operators.clj
+++ b/src/main/clojure/clojure/core/matrix/row_operators.clj
@@ -1,4 +1,7 @@
-(ns clojure.core.matrix.row-operators)
+(ns clojure.core.matrix.row-operators
+  (:use [clojure.core.matrix :only [e*]])
+  (:use clojure.core.matrix.operators)
+  (:refer-clojure :exclude [* - + / ==]))
 
 (defn swap 
   "Swap row i with row j"
@@ -8,12 +11,9 @@
 (defn multiply
   "Multiply row i by constant k"
   [X i k]
-  (assoc X i (map #(* k)
-                  (X i))))
+  (assoc X i (e* k (X i))))
 
 (defn add
   "Add a row j times a constant k to a row i and replace i"
   [X i j k]
-  (assoc X i (+ (X i) (map #(* k %)
-                           (X j)))))
-
+  (assoc X i (+ (X i) (* k (X j)))))

--- a/src/main/clojure/clojure/core/matrix/row_operators.clj
+++ b/src/main/clojure/clojure/core/matrix/row_operators.clj
@@ -1,3 +1,5 @@
+(ns clojure.core.matrix.row-operators)
+
 (defn swap 
   "Swap row i with row j"
   [X i j] 
@@ -6,10 +8,12 @@
 (defn multiply
   "Multiply row i by constant k"
   [X i k]
-  (assoc X i (* k (X i))))
+  (assoc X i (map #(* k)
+                  (X i))))
 
 (defn add
   "Add a row j times a constant k to a row i and replace i"
   [X i j k]
-  (assoc X i (+ (X i) (* k (X j)))))
+  (assoc X i (+ (X i) (map #(* k %)
+                           (X j)))))
 

--- a/src/test/clojure/clojure/core/matrix/test_row_operators.clj
+++ b/src/test/clojure/clojure/core/matrix/test_row_operators.clj
@@ -1,0 +1,11 @@
+(deftest test-swap
+  (testing "vector row swap"
+    (is (== [0 2] (swap [2 0] 0 1)))
+    (is (== [0 2] (swap [2 0] 1 0)))
+    (is (== [0 2] (swap [[2 0]] 0 1))))
+  (testing "matrix row swap"
+    (is (== [[0 2] [2 0]] (swap [[2 0] [0 2]] 0 1)))
+    (is (== [[0 2] [2 0] [1 1]] (swap [[1 1] [2 0] [0 2]] 0 2)))))
+
+(deftest test-mul)
+

--- a/src/test/clojure/clojure/core/matrix/test_row_operators.clj
+++ b/src/test/clojure/clojure/core/matrix/test_row_operators.clj
@@ -13,7 +13,7 @@
 
 (deftest test-multiply
   (testing "multiply row i by constant k"
-    (is (= [0 2 4] (multiply [[0 1 2]] 0 2)))))
+    (is (= [[0 2 4]] (multiply [[0 1 2]] 0 2)))))
 
 (deftest test-add
   (testing "add row j to i and replace i with the result"

--- a/src/test/clojure/clojure/core/matrix/test_row_operators.clj
+++ b/src/test/clojure/clojure/core/matrix/test_row_operators.clj
@@ -1,3 +1,8 @@
+(ns clojure.core.matrix.test-api
+  (:use clojure.test)
+  (:use clojure.core.matrix.row_operators))
+
+
 (deftest test-swap
   (testing "vector row swap"
     (is (== [0 2] (swap [2 0] 0 1)))
@@ -7,5 +12,10 @@
     (is (== [[0 2] [2 0]] (swap [[2 0] [0 2]] 0 1)))
     (is (== [[0 2] [2 0] [1 1]] (swap [[1 1] [2 0] [0 2]] 0 2)))))
 
-(deftest test-mul)
+(deftest test-multiply
+  (testing "multiply row i by constant k"
+    (is (== [0 2 4] (multiply [[0 1 2]] 2)))))
 
+(deftest test-add
+  (testing "add row j to i and replace i with the result"
+    (is (== [[3 3] [1 1]] (add [[1 1] [1 1]] 0 1 2 )))))

--- a/src/test/clojure/clojure/core/matrix/test_row_operators.clj
+++ b/src/test/clojure/clojure/core/matrix/test_row_operators.clj
@@ -14,7 +14,7 @@
 
 (deftest test-multiply
   (testing "multiply row i by constant k"
-    (is (== [0 2 4] (multiply [[0 1 2]] 2)))))
+    (is (== [0 2 4] (multiply [[0 1 2]] 0 2)))))
 
 (deftest test-add
   (testing "add row j to i and replace i with the result"

--- a/src/test/clojure/clojure/core/matrix/test_row_operators.clj
+++ b/src/test/clojure/clojure/core/matrix/test_row_operators.clj
@@ -1,21 +1,20 @@
-(ns clojure.core.matrix.test-api
+(ns clojure.core.matrix.test-row-operators
   (:use clojure.test)
-  (:use clojure.core.matrix.row_operators))
+  (:use clojure.core.matrix.row-operators))
 
 
 (deftest test-swap
   (testing "vector row swap"
-    (is (== [0 2] (swap [2 0] 0 1)))
-    (is (== [0 2] (swap [2 0] 1 0)))
-    (is (== [0 2] (swap [[2 0]] 0 1))))
+    (is (= [0 2] (swap [2 0] 0 1)))
+    (is (= [0 2] (swap [2 0] 1 0))))
   (testing "matrix row swap"
-    (is (== [[0 2] [2 0]] (swap [[2 0] [0 2]] 0 1)))
-    (is (== [[0 2] [2 0] [1 1]] (swap [[1 1] [2 0] [0 2]] 0 2)))))
+    (is (= [[0 2] [2 0]] (swap [[2 0] [0 2]] 0 1)))
+    (is (= [[0 2] [2 0] [1 1]] (swap [[1 1] [2 0] [0 2]] 0 2)))))
 
 (deftest test-multiply
   (testing "multiply row i by constant k"
-    (is (== [0 2 4] (multiply [[0 1 2]] 0 2)))))
+    (is (= [0 2 4] (multiply [[0 1 2]] 0 2)))))
 
 (deftest test-add
   (testing "add row j to i and replace i with the result"
-    (is (== [[3 3] [1 1]] (add [[1 1] [1 1]] 0 1 2 )))))
+    (is (= [[3 3] [1 1]] (add [[1 1] [1 1]] 0 1 2 )))))


### PR DESCRIPTION
I have added row_operators.clj and test_row_operators.clj.

The contribution is three functions for elementary row operations:

**(swap [X i j]**
    swaps row i with row j

**(multiply [X i k])**
    multiply row i by k

**(add [X i j k])**
    add row j times k to row i
