### PR TITLE
Simple benchmark for matrix multiplication, faster default matrix multiplication, slight API change

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,4 +11,5 @@
                                   [criterium/criterium "0.4.1"]
                                   [hiccup "1.0.3"]
                                   [net.mikera/vectorz-clj "0.13.0"]]
-                   :source-paths ["src/main/clojure" "src/dev/clojure"]}})
+                   :source-paths ["src/main/clojure" "src/dev/clojure"]
+                   :jvm-opts ^:replace []}})

--- a/src/dev/clojure/clojure/core/matrix/docgen/bench.clj
+++ b/src/dev/clojure/clojure/core/matrix/docgen/bench.clj
@@ -1,5 +1,6 @@
 (ns clojure.core.matrix.docgen.bench
   (:require [criterium.core :as cr]
+            [clojure.core.matrix :as m]
             [clojure.core.matrix.protocols :as mp]
             [clojure.core.matrix.implementations :as imp]
             [clojure.core.matrix.multimethods :as mm]
@@ -10,11 +11,27 @@
            :reference :vectorz
            :fast-bench true})
 
-(defn bench-proto [proto]
-  ()
-  )
+(defn rand-mtx
+  ([n] (rand-mtx n 1000 identity))
+  ([n max caster]
+     (letfn [(rand-row [] (->> #(rand-int max)
+                               repeatedly (map caster) (take n) vec))]
+       (->> rand-row repeatedly (take n) vec))))
 
-(defn generate []
-  (let [protos (c/extract-protocols)]
-
-    ))
+(defn mmultiply-bench []
+  (let [n 50]
+    (println "Test matrix size:" n)
+    (println "Vectorz:")
+    (let [[ma mb] (->> #(rand-mtx n)
+                       repeatedly (map #(m/array :vectorz %)) (take 2))]
+      (cr/report-result (cr/quick-benchmark (mp/matrix-multiply ma mb) {})))
+    (println "-----")
+    (println "Persistent vectors:")
+    (let [[ma mb] (->> #(rand-mtx n)
+                       repeatedly (take 2))]
+      (cr/report-result (cr/quick-benchmark (mp/matrix-multiply ma mb) {})))
+    (println "-----")
+    (println "NDArray:")
+    (let [[ma mb] (->> #(rand-mtx n)
+                       repeatedly (map #(m/array :ndarray %)) (take 2))]
+      (cr/report-result (cr/quick-benchmark (mp/matrix-multiply ma mb) {})))))

--- a/src/dev/clojure/clojure/core/matrix/docgen/bench.clj
+++ b/src/dev/clojure/clojure/core/matrix/docgen/bench.clj
@@ -1,0 +1,20 @@
+(ns clojure.core.matrix.docgen.bench
+  (:require [criterium.core :as cr]
+            [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.multimethods :as mm]
+            [clojure.core.matrix.implementations :as mi]
+            [clojure.core.matrix.docgen.common :as c]))
+
+(def conf {:tobench [:vectorz :ndarray]
+           :reference :vectorz
+           :fast-bench true})
+
+(defn bench-proto [proto]
+  ()
+  )
+
+(defn generate []
+  (let [protos (c/extract-protocols)]
+
+    ))

--- a/src/dev/clojure/clojure/core/matrix/docgen/bench.clj
+++ b/src/dev/clojure/clojure/core/matrix/docgen/bench.clj
@@ -19,7 +19,7 @@
        (->> rand-row repeatedly (take n) vec))))
 
 (defn mmultiply-bench []
-  (let [n 50]
+  (let [n 70]
     (println "Test matrix size:" n)
     (println "Vectorz:")
     (let [[ma mb] (->> #(rand-mtx n)

--- a/src/dev/clojure/clojure/core/matrix/docgen/common.clj
+++ b/src/dev/clojure/clojure/core/matrix/docgen/common.clj
@@ -1,0 +1,72 @@
+(ns clojure.core.matrix.docgen.common
+  (:require [clojure.reflect :as r]
+            [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.multimethods :as mm]
+            [clojure.core.matrix.implementations :as mi]
+            [criterium.core :as cr]))
+
+(defn protocol?
+  "Returns true if an argument is a protocol'"
+  [p]
+  (and (map? p)
+       (:on-interface p)
+       (.isInterface (:on-interface p))))
+
+(defn enhance-protocol-kv
+  "Transform MapEntry to just map with some additional fields"
+  [[name p]]
+  (let [m (->> @p :var meta)]
+    (assoc @p :line (:line m) :file (:file m) :name name)))
+
+(defn extract-protocols
+  "Extracts protocol info from clojure.core.matrix.protocols"
+  []
+  (->> (ns-publics 'clojure.core.matrix.protocols)
+       (filter (comp protocol? deref val))
+       (map enhance-protocol-kv)
+       (sort-by :line)))
+
+(defn get-impl-objs
+  "Returns a list of available implementations' objects"
+  []
+  (filter second
+          (for [[name ns] mi/KNOWN-IMPLEMENTATIONS
+                :when (not (#{:TODO :persistent-vector} ns))]
+            (try
+              {:name name, :obj (mi/get-canonical-object name)}
+              (catch Throwable t nil)))))
+
+(defn extends-deep?
+  "This functions differs from ordinary `extends?` by using `extends?`
+   on all ancestors of given type instead of just type itself. It also
+   skips `java.lang.Object` that serves as a default implementation
+   for all protocols"
+  [proto cls]
+  ;; Here we need a special case to avoid reflecting on primitive type
+  ;; (it will cause an exception)
+  (if (= (Class/forName "[D") cls)
+    (extends? proto cls)
+    (let [bases (-> cls (r/type-reflect :ancestors true) :ancestors)]
+      (->> bases
+           (filter (complement #{'java.lang.Object}))
+           (map resolve)
+           (cons cls)
+           (map (partial extends? proto))
+           (some true?)))))
+
+(defn find-implementers
+  "Returns a set of implementation names of implementations that
+   support provided protocol"
+  [protocol impl-objs]
+  (->> impl-objs
+       (filter #(->> % :obj class (extends-deep? protocol)))
+       (map :name)
+       (into #{})))
+
+(defn extract-implementations
+  "Returns a a sequence of protocol maps augmented with :implemented-by key
+   that contains a set of names of supporting implementations"
+  [protocols impl-objs]
+  (for [proto protocols]
+    (assoc proto :implemented-by (find-implementers proto impl-objs))))

--- a/src/dev/clojure/clojure/core/matrix/docgen/implementations.clj
+++ b/src/dev/clojure/clojure/core/matrix/docgen/implementations.clj
@@ -1,9 +1,11 @@
 (ns clojure.core.matrix.docgen.implementations
   (:use [clojure.java.shell :only [sh]])
   (:require [clojure.reflect :as r]
-            [clojure.core.matrix.protocols :as mp]
-            [clojure.core.matrix.implementations :as mi]
-            [hiccup.page :as h]))
+            [clojure.string :as s]
+            [hiccup.page :as h]
+            #_[clojure.core.matrix.protocols :as mp]
+            #_[clojure.core.matrix.implementations :as mi]
+            #_[clojure.core.matrix.docgen.common :as c]))
 
 ;; ## Info
 ;; This file provides rather hacky solution for generating
@@ -13,77 +15,12 @@
 (def repo-url "https://github.com/mikera/matrix-api")
 (def src-path "src/main/clojure")
 
-(defn protocol?
-  "Returns true if an argument is a protocol'"
-  [p]
-  (and (map? p)
-       (:on-interface p)
-       (.isInterface (:on-interface p))))
-
-(defn enhance-protocol-kv
-  "Transform MapEntry to just map with some additional fields"
-  [[name p]]
-  (let [m (->> @p :var meta)]
-    (assoc @p :line (:line m) :file (:file m) :name name)))
-
-(defn extract-protocols
-  "Extracts protocol info from clojure.core.matrix.protocols"
-  []
-  (->> (ns-publics 'clojure.core.matrix.protocols)
-       (filter (comp protocol? deref val))
-       (map enhance-protocol-kv)
-       (sort-by :line)))
-
-(defn get-impl-objs
-  "Returns a list of available implementations' objects"
-  []
-  (filter second
-          (for [[name ns] mi/KNOWN-IMPLEMENTATIONS
-                :when (not (#{:TODO :persistent-vector} ns))]
-            (try
-              {:name name, :obj (mi/get-canonical-object name)}
-              (catch Throwable t nil)))))
-
-(defn extends-deep?
-  "This functions differs from ordinary `extends?` by using `extends?`
-   on all ancestors of given type instead of just type itself. It also
-   skips `java.lang.Object` that serves as a default implementation
-   for all protocols"
-  [proto cls]
-  ;; Here we need a special case to avoid reflecting on primitive type
-  ;; (it will cause an exception)
-  (if (= (Class/forName "[D") cls)
-    (extends? proto cls)
-    (let [bases (-> cls (r/type-reflect :ancestors true) :ancestors)]
-      (->> bases
-           (filter (complement #{'java.lang.Object}))
-           (map resolve)
-           (cons cls)
-           (map (partial extends? proto))
-           (some true?)))))
-
-(defn find-implementers
-  "Returns a set of implementation names of implementations that
-   support provided protocol"
-  [protocol impl-objs]
-  (->> impl-objs
-       (filter #(->> % :obj class (extends-deep? protocol)))
-       (map :name)
-       (into #{})))
-
-(defn extract-implementations
-  "Returns a a sequence of protocol maps augmented with :implemented-by key
-   that contains a set of names of supporting implementations"
-  [protocols impl-objs]
-  (for [proto protocols]
-    (assoc proto :implemented-by (find-implementers proto impl-objs))))
-
 (defn get-git-hash
   "Returns current revision's git hash"
   []
   (-> (sh "git" "log" "--pretty=format:'%H'" "-n 1")
       :out
-      (clojure.string/replace #"'" "")))
+      (s/replace #"'" "")))
 
 (defn render-header
   [git-hash]
@@ -99,7 +36,7 @@
   (let [src-href (str repo-url "/blob/" git-hash "/" src-path "/"
                       (:file p) "#L" (:line p))
         doc-title (if (:doc p)
-                    {:title  (clojure.string/replace (:doc p) #"\s+" " ")}
+                    {:title  (s/replace (:doc p) #"\s+" " ")}
                     {})]
     (seq [[:span doc-title
            (:name p)]
@@ -116,8 +53,7 @@
                 impl-doc (try (-> impl-obj :obj mp/meta-info :doc)
                               (catch IllegalArgumentException e nil))
                 impl-title (if impl-doc
-                             {:title (clojure.string/replace impl-doc
-                                                             #"\s+" " ")}
+                             {:title (s/replace impl-doc #"\s+" " ")}
                              {})]]
       [:th [:span impl-title
             impl-name]])]
@@ -144,8 +80,8 @@
 
 (defn generate
   []
-  (let [impl-objs (get-impl-objs)
-        protos (extract-implementations (extract-protocols) impl-objs)
+  (let [impl-objs (c/get-impl-objs)
+        protos (c/extract-implementations (c/extract-protocols) impl-objs)
         git-hash (get-git-hash)
         header (render-header git-hash)
         table (render-table impl-objs protos git-hash)

--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -428,7 +428,7 @@
 
 (defn test-identity [im]
   (let [I (identity-matrix im 3)]
-    (is (equals [1 2 3] (mul I [1 2 3])))
+    (is (equals [[1] [2] [3]] (mul I [[1] [2] [3]])))
     (is (equals I (transpose I)))))
 
 (defn test-trace [im]
@@ -439,7 +439,7 @@
 
 (defn test-diagonal [im]
   (let [I (diagonal-matrix im [1 2 3])]
-    (is (equals [1 4 9] (mul I [1 2 3])))
+    (is (equals [[1] [4] [9]] (mul I [[1] [2] [3]])))
     (is (equals I (transpose I)))))
 
 (defn test-row-column-matrices [im]

--- a/src/main/clojure/clojure/core/matrix/utils.clj
+++ b/src/main/clojure/clojure/core/matrix/utils.clj
@@ -164,4 +164,17 @@
           r (broadcast-shape* a b)]
       (if r (reverse r) nil))))
 
+(defmacro c-for
+  "C-like loop with nested loops support"
+  [loops & body]
+  (letfn [(c-for-rec [loops body-stmts]
+            (if (seq loops)
+              (let [[var init check next] (take 4 loops)]
+                `((loop [~var ~init]
+                     (when ~check
+                       ~@(c-for-rec (nthrest loops 4) body-stmts)
+                       (recur ~next)))))
+              body-stmts))]
+    `(do ~@(c-for-rec loops body) nil)))
 
+#_(c-for [i (long 0) (< i mrows) (inc i)])


### PR DESCRIPTION
I'm sorry in advance for a very messy PR.

This PR contains:
- a simple benchmark for matrix multiplication that compares vectorz, PersistentVector and NDArray
- a lot faster default implementation of matrix multiplication (2-3x speedup over previous PersistentVector-coercing solution);
- default matrix multiplication API and corresponding tests are slightly changed — matrix multiplication now accepts only 2 matrices (arrays of dimensionality 2) and returns a matrix (reflecting discussion in google group).
