### PR TITLE
identity-matrix? and zero-matrix? predicates

### DIFF
--- a/src/main/clojure/clojure/core/matrix.clj
+++ b/src/main/clojure/clojure/core/matrix.clj
@@ -278,6 +278,16 @@
   [m]
   (== 0 (mp/dimensionality m)))
 
+(defn identity-matrix?
+  "Returns true if the parameter is an identity-matrix"
+  [m]
+  (mp/identity-matrix? m))
+
+(defn zero-matrix?
+  "Returns true if all the elements of the parameter are zeros"
+  [m]
+  (mp/zero-matrix? m))
+
 (defn element-type
   "Returns the class of elements that can be in the array. For example, a numerical array may return
    the class java.lang.Double."

--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -401,7 +401,6 @@
   (is (= (seq (map inc (eseq m))) (seq (eseq (emap inc m))))))
 
 (defn test-numeric-matrix-predicates [m]
-  (prn "m ist " m)
   (when (and (matrix? m) (= 2 (dimensionality m)))
     (is (zero-matrix? (new-matrix m 10 10)))
     (is (identity-matrix? (identity-matrix m 5)))

--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -372,11 +372,23 @@
   (is (equals (esum m) (ereduce + m)))
   (is (= (seq (map inc (eseq m))) (seq (eseq (emap inc m))))))
 
+(defn test-numeric-matrix-predicates [m]
+  (prn "m ist " m)
+  (when (and (matrix? m) (= 2 (dimensionality m)))
+    (is (zero-matrix? (new-matrix m 10 10)))
+    (is (identity-matrix? (identity-matrix m 5)))
+    (is (not (identity-matrix? (array m [[2 0][0 1]]))))
+    (is (not (zero-matrix? (array m [[0 0][0 1]]))))
+    (is (identity-matrix? (array m [[1.0 0.0][0.0 1.0]])))
+    (is (zero-matrix? (array m [[0.0]])))
+    (is (not (identity-matrix? (array m [[1.0 0.0]]))))))
+  
 (defn test-numeric-instance [m]
   (is (numerical? m))
-;  (test-generic-numerical-assumptions m)
+ ;  (test-generic-numerical-assumptions m)
   (numeric-scalar-tests m)
-  (misc-numeric-tests m))
+  (misc-numeric-tests m)
+  (test-numeric-matrix-predicates m))
 
 ;; ========================================
 ;; 1D vector tests

--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -412,7 +412,7 @@
   
 (defn test-numeric-instance [m]
   (is (numerical? m))
- ;  (test-generic-numerical-assumptions m)
+ ; (test-generic-numerical-assumptions m)
   (numeric-scalar-tests m)
   (misc-numeric-tests m)
   (test-numeric-matrix-predicates m))

--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -946,6 +946,34 @@
                  (assoc zs i (nth diagonal-values i))))]
         (mp/coerce-param m dm))))
 
+(extend-protocol mp/PMatrixPredicates
+  java.lang.Object
+  (identity-matrix? [m]
+    (let [rc (mp/dimension-count m 0)
+          cc (mp/dimension-count m 1)]
+      (if (== rc cc)
+        (loop [i (long 0)]
+          (if (< i rc)
+            (if (loop [j (long 0)]
+                  (if (< j cc)
+                    (let [elem (mp/get-2d m i j)]
+                      (if (nil? elem)
+                        false
+                        (if (== i j)
+                          (if (== elem 1) (recur (inc j)) false)
+                          (if (== elem 0) (recur (inc j)) false))))
+                    true))
+              (recur (inc i))
+              false)
+            true))
+        false)))
+  (zero-matrix? [m]
+    (every? #(and (not (nil? %)) (zero? %)) (mp/element-seq m)))
+  nil
+  (identity-matrix? [m] false)
+  (zero-matrix? [m] false))
+                  
+
 ;; =======================================================
 ;; default multimethod implementations
 

--- a/src/main/clojure/clojure/core/matrix/protocols.clj
+++ b/src/main/clojure/clojure/core/matrix/protocols.clj
@@ -497,6 +497,16 @@
     [m f init]
     "Reduces with the function f over all elements of m."))
 
+
+(defprotocol PMatrixPredicates
+  "Protocol for matrix predicates like identity-matrix? or zero-matrix?"
+  (identity-matrix?
+    [m]
+    "returns true if the matrix m is an identity-matrix")
+  (zero-matrix?
+    [m]
+    "returns true if all the elements of matrix m are zeros"))
+
 ;; ============================================================
 ;; Generic values and functions
 ;;


### PR DESCRIPTION
This pr adds the predicate functions identity-matrix? and zero-matrix? to the public api.
They are backed by a protocol and have a default implementation for Object and nil.
Added tests for the predicates to the compliance tester.
All tests pass.
