### PR TITLE
Adding commons-math to KNOWN-IMPLEMENTATIONS

### DIFF
--- a/src/main/clojure/clojure/core/matrix/implementations.clj
+++ b/src/main/clojure/clojure/core/matrix/implementations.clj
@@ -28,7 +28,7 @@
    :parallel-colt :TODO
    :ejml :TODO
    :ujmp :TODO
-   :commons-math :TODO))
+   :commons-math 'apache-commons-matrix.core))
 
 ;; default implementation to use
 ;; should be included with clojure.core.matrix for easy of use


### PR DESCRIPTION
I needed to use some of the more esoteric decompositions available in Apache Commons Math.  I really liked the interface provided by core.matrix and I wanted to learn more about Clojure's protocols, so I went ahead and tried adding support.

Following your instructions in the Implementation Guide, I've added it to the KNOWN-IMPLEMENTATIONS map.

I'd appreciate any feedback you have on my implementation.  Thanks!
