### PR TITLE
Improve pretty-print spacing on multi-column rows

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/pprint.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/pprint.clj
@@ -25,7 +25,7 @@
   [[elem-head & elem-tail] [len-head & len-tail]] ;; the first element doesn't have a leading ws.
   (let [first-elem (str-elem elem-head len-head)
         body-elems (map str-elem elem-tail len-tail)]
-  (str "[" first-elem " " (apply str body-elems) "]")))
+  (str "[" first-elem (apply str (map #(str " " %) body-elems)) "]")))
 
 (defn- rprint
   "Recursively prints each element with a leading


### PR DESCRIPTION
Minor change to improve spacing when pretty-printing multi-column rows.

Instead of:

user=> (pm (matrix [[3 4 5][2 4 6]]))
[[3.000 4.0005.000]
 [2.000 4.0006.000]]
nil

With change:

user=> (pm (matrix [[3 4 5][2 4 6]]))
[[3.000 4.000 5.000]
 [2.000 4.000 6.000]]
nil

Signed-off-by: John Poplett john.poplett@acm.com
