### PR TITLE
Implemented Division Protocols for Double Array

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/double_array.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/double_array.clj
@@ -267,16 +267,22 @@
              (dotimes [i (alength m)]
                (aset m i (/ 1.0 / (aget m i))))
              nil))
-    ([m a] (let [^doubles m m]
-             (dotimes [i (alength m)]
-               (aset m i (/ (aget m i) a)))))))
+    ([m a] (if (number? a)
+             (let [^doubles m m]
+               (dotimes [i (alength m)]
+                 (aset m i (/ (aget m i) a))))
+             (let [[^doubles m ^doubles a] (mp/broadcast-compatible m a)]
+               (dotimes [i (alength m)]
+                 (aset m i (/ (aget m i) (aget a i)))))))))
 
 (extend-protocol mp/PMatrixDivide
   (Class/forName "[D")
   (element-divide
     ([m] (mp/element-map m #(/ %)))
-    ([m a] (let [[m a] (mp/broadcast-compatible m a)]
-             (mp/element-map m #(/ %1 %2) a)))))
+    ([m a] (if (number? a)
+             (mp/element-map m #(/ % a))
+             (let [[m a] (mp/broadcast-compatible m a)]
+               (mp/element-map m #(/ %1 %2) a))))))
 
 ;; registration
 

--- a/src/main/clojure/clojure/core/matrix/impl/double_array.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/double_array.clj
@@ -275,7 +275,8 @@
   (Class/forName "[D")
   (element-divide
     ([m] (mp/element-map m #(/ %)))
-    ([m a] (mp/element-map m #(/ % a)))))
+    ([m a] (let [[m a] (mp/broadcast-compatible m a)]
+             (mp/element-map m #(/ %1 %2) a)))))
 
 ;; registration
 

--- a/src/main/clojure/clojure/core/matrix/impl/double_array.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/double_array.clj
@@ -260,6 +260,23 @@
         (let [^doubles m m]
           (reduce f init m)))))
 
+(extend-protocol mp/PMatrixDivideMutable
+  (Class/forName "[D")
+  (element-divide!
+    ([m] (let [^doubles m m]
+             (dotimes [i (alength m)]
+               (aset m i (/ 1.0 / (aget m i))))
+             nil))
+    ([m a] (let [^doubles m m]
+             (dotimes [i (alength m)]
+               (aset m i (/ (aget m i) a)))))))
+
+(extend-protocol mp/PMatrixDivide
+  (Class/forName "[D")
+  (element-divide
+    ([m] (mp/element-map m #(/ %)))
+    ([m a] (mp/element-map m #(/ % a)))))
+
 ;; registration
 
 (imp/register-implementation (double-array [1]))


### PR DESCRIPTION
I had the time to look over and create PMatrixDivideMutable and PMatrixDivide for the double array. I tended towards performance with this implementation, which is why I try to avoid the mp/broadcast-compatible if the array is being divided by a number (opposed to another array).

Additionally, on the div!, I avoided using element-map to avoid the unnecessary copy and mp/assign!.

Let me know how this looks.
