### PR TITLE
Add default matrix-multiply for two vectors

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -598,6 +598,7 @@
             adims (long (mp/dimensionality a))]
         (cond
          (== adims 0) (mp/scale m a)
+         (and (== mdims 1) (== adims 1)) (mp/vector-dot m a)
          (and (== mdims 1) (== adims 2))
            (let [[arows acols] (mp/get-shape a)]
              (mp/reshape (mp/matrix-multiply (mp/reshape m [1 arows]) a)


### PR DESCRIPTION
Currently, default implementations of matrix-multiply are provided for all combinations of scalars, vectors, and matrices except for two vectors. This adds the default implementation for two vectors, which is vector-dot.
