### PR TITLE
Implemented order

### DIFF
--- a/src/main/clojure/clojure/core/matrix.clj
+++ b/src/main/clojure/clojure/core/matrix.clj
@@ -788,6 +788,13 @@
   ([m shifts]
     (mp/rotate-all m shifts)))
 
+(defn order
+  "Reorders columns of an array along specified dimension."
+  ([m cols]
+     (mp/order m cols))
+  ([m dimension cols]
+     (mp/order m dimension cols)))
+
 (defn as-vector
   "Creates a view of an array as a single flattened vector.
    Returns nil if this is not supported by the implementation."

--- a/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
@@ -254,6 +254,14 @@
             (vec (concat (subvec m sh c) (subvec m 0 sh)))))
         (mapv (fn [s] (mp/rotate s (dec dim) places)) m))))
 
+(extend-protocol mp/POrder
+  IPersistentVector
+  (order
+    ([m cols]
+       (mp/order m 0 cols))
+    ([m dimension cols]
+       (mapmatrix #(mp/get-slice m dimension %) cols))))
+
 (extend-protocol mp/PSubVector
   IPersistentVector
     (subvector [m start length]

--- a/src/main/clojure/clojure/core/matrix/protocols.clj
+++ b/src/main/clojure/clojure/core/matrix/protocols.clj
@@ -543,6 +543,12 @@
   (transpose! [m]
     "Transposes a mutable 2D matrix in place"))
 
+(defprotocol POrder
+  "Protocol for matrix reorder"
+  (order
+    [m cols]
+    [m dimension cols]))
+
 (defprotocol PNumerical
   "Protocol for identifying numerical arrays. Should return true if every element in the
    array is a valid numerical value."

--- a/src/test/clojure/clojure/core/matrix/test_persistent_vector_implementation.clj
+++ b/src/test/clojure/clojure/core/matrix/test_persistent_vector_implementation.clj
@@ -69,6 +69,12 @@
 (deftest test-rotate
   (is (equals [2 3 1] (rotate [1 2 3] 0 1))))
 
+(deftest test-order
+  (is (equals [1 3 3] (order [1 2 3 4] [0 2 2])))
+  (is (equals [[1 4] [2 5]] (order [[1 2 3] [4 5 6]] 1 [0 1])))
+  (is (error? (order [1 2] 1 [0])))
+  (is (error? (order [1 2] [2]))))
+
 (deftest test-dot
   (is (equals [2 4 6] (dot 2 [1 2 3])))
   (is (equals [2 4 6] (dot [1 2 3] 2)))


### PR DESCRIPTION
Implementation of https://github.com/mikera/core.matrix/issues/84

Some examples:

``` clojure
(order [:a :b :c :d] [0 2 2])
=> [:a :c :c]
```

``` clojure
(order [[:a :b :c]
        [:e :f :g]] 1 [1 2])
=> [[:b :f] [:c :g]]
```
