### PR TITLE
Fixed the consistent shape check in convert-to-nested-vectors.

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
@@ -469,8 +469,9 @@
     (convert-to-nested-vectors [m]
       (if (is-nested-persistent-vectors? m)
         m
-        (let [m (mapv-identity-check mp/convert-to-nested-vectors m)]
-          (if (reduce = (map mp/get-shape m))
+        (let [m (mapv-identity-check mp/convert-to-nested-vectors m)
+              m-shapes (map mp/get-shape m)]
+          (if (every? (partial = (first m-shapes)) (rest m-shapes))
             m
             (error "Can't convert to persistent vector array: inconsistent shape."))))))
 


### PR DESCRIPTION
The check that nested vectors had the same shape was incorrect. The bug causes the check to always fail.

A simple test case that creates a Clojure persistent vector with three rows, each a vectorz Vector. The test case assumes that vectorz is the selected implementation.

`(convert-to-nested-vectors (vec (repeat 3 (clojure.core.matrix/new-vector 5)))`
