### PR TITLE
Bug in dataset set-2d implementation

### DIFF
--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -595,6 +595,12 @@
     (is (equals [[1 2] [1 2]] (broadcast (matrix im [1 2]) [2 2])))
     ))
 
+(defn test-matrix-mset [im]
+  (let [m (matrix im [[1 2] [3 4]])]
+    (is (equals [[5 2] [3 4]] (mset m 0 0 5)))
+    (is (equals [[1 2] [5 4]] (mset m 1 0 5)))
+    (is (equals [[1 2] [3 5]] (mset m 1 1 5)))))
+
 (defn test-2d-instances [im]
   (test-numeric-instance (matrix im [[1 2] [3 4]]))
   (test-numeric-instance (matrix im [[1 2]]))
@@ -609,7 +615,8 @@
   (test-matrix-emul im)
   (test-identity im)
   (test-order im)
-  (test-2d-instances im))
+  (test-2d-instances im)
+  (test-matrix-mset im))
 
 ;; ======================================
 ;; Instance test function

--- a/src/main/clojure/clojure/core/matrix/impl/dataset.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/dataset.clj
@@ -104,7 +104,7 @@
       (error "Can't do 1D set on a DataSet"))
     (set-2d [m x y v]
       (let [col (column m y)]
-        (dataset (.column-names m) (assoc (.columns m) (assoc col x v)))))
+        (dataset (.column-names m) (assoc (.columns m) y (assoc col x v)))))
     (set-nd [m indexes v]
       (let [dims (long (count indexes))]
         (cond 


### PR DESCRIPTION
Currently, if you try to call mp/set-2d on a dataset instance, you will get an error:
`ArityException Wrong number of args (2) passed to: core$assoc  clojure.lang.AFn.throwArity (AFn.java:437)`
This PR provides the solution to this bug plus a compliance test for mset.
