### PR TITLE
Object-array PMatrixSlices implementation fixed

### DIFF
--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -607,6 +607,13 @@
   (test-numeric-instance (matrix im [[10]]))
   (test-numeric-instance (matrix im [[10] [11]])))
 
+(defn test-matrix-slices [im]
+  (let [m (matrix im [[1 2 3] [4 5 6]])]
+    (is (equals [1 2 3] (get-row m 0)))
+    (is (equals [2 5] (get-column m 1)))
+    (is (equals [4 5 6] (slice m 1)))
+    (is (equals [3 6] (slice m 1 2)))))
+
 (defn matrix-tests-2d [im]
   (test-row-column-matrices im)
   (test-transpose im)
@@ -616,7 +623,8 @@
   (test-identity im)
   (test-order im)
   (test-2d-instances im)
-  (test-matrix-mset im))
+  (test-matrix-mset im)
+  (test-matrix-slices im))
 
 ;; ======================================
 ;; Instance test function

--- a/src/main/clojure/clojure/core/matrix/impl/object_array.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/object_array.clj
@@ -226,13 +226,17 @@
 (extend-protocol mp/PMatrixSlices
   (Class/forName "[Ljava.lang.Object;")
     (get-row [m i]
-      (aget ^objects m (long i)))
+      (mp/get-major-slice m i))
     (get-column [m i]
-      (mp/get-major-slice (aget ^objects m (long i)) i))
+      (mp/get-slice m 1 i))
     (get-major-slice [m i]
       (aget ^objects m (long i)))
     (get-slice [m dimension i]
-      (aget ^objects m (long i))))
+      (let [dimension (long dimension)]
+        (if (== dimension 0)
+          (mp/get-major-slice m i)
+          (let [sd (dec dimension)]
+            (mapv #(mp/get-slice % sd i) m))))))
 
 (extend-protocol mp/PSliceView
   (Class/forName "[Ljava.lang.Object;")


### PR DESCRIPTION
Currently, get-column and get-slice do not work for object-array. This PR introduces correct implementation and compliance tests for these functions.
