### PR TITLE
fixed slice behaviour for 1-d arrays

### DIFF
--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -169,6 +169,10 @@
               (is (= (mutable? fss) (mutable? m)))))
           (is (e= m slcs)))))))
 
+(defn test-slice-returns-scalar-on-1d [m]
+  (when (and (= 1 (dimensionality m)) (> (ecount m) 0))
+    (is (scalar? (slice m 0)))))
+
 (defn test-submatrix-assumptions [m]
   (let [shp (shape m)
         dims (dimensionality m)
@@ -271,6 +275,7 @@
   (test-join m)
   (test-dimensionality-assumptions m)
   (test-slice-assumptions m)
+  (test-slice-returns-scalar-on-1d m)
   (test-submatrix-assumptions m)
   (test-mutable-assumptions m)
   (test-vector-round-trip m)

--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -1105,7 +1105,8 @@
       (mp/get-slice m 1 i))
     (get-major-slice [m i]
       (cond 
-        (java-array? m) (nth m i)
+       (java-array? m) (nth m i)
+       (== 1 (mp/dimensionality m)) (mp/get-1d m i)
         :else (clojure.core.matrix.impl.wrappers/wrap-slice m i)))
     (get-slice [m dimension i]
       (cond

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
@@ -644,7 +644,12 @@
     (get-major-slice [m i]
       (row-major-slice#t m i))
     (get-slice [m dimension i]
-      (arbitrary-slice#t m dimension i))
+               ;;get-slice requires to return a scalar for a slice of a 1-dim
+               ;;array
+               (let [res (arbitrary-slice#t m dimension i)]
+                 (if (= 1 ndims)
+                   (mp/get-0d res)
+                   res)))
 
   mp/PSubVector
     (subvector [m start length]

--- a/src/test/clojure/clojure/core/matrix/test_api.clj
+++ b/src/test/clojure/clojure/core/matrix/test_api.clj
@@ -200,6 +200,10 @@
   (testing "slices of a standard vector are scalar numbers"
     (is (= [1 2 3] (slices (array [1 2 3]))))))
 
+(deftest test-slice-on-1d
+  (testing "slice on 1d must return scalar"
+    (is (scalar? (slice [1 2 3] 0)))))
+
 (deftest test-submatrix
   (is (equals [[3]] (submatrix (array [[1 2] [3 4]]) [[1 1] [0 1]])))
   (is (equals [[2] [4]] (submatrix (array [[1 2] [3 4]]) 1 [1 1])))

--- a/src/test/clojure/clojure/core/matrix/test_ndarray_implementation.clj
+++ b/src/test/clojure/clojure/core/matrix/test_ndarray_implementation.clj
@@ -119,6 +119,9 @@
   (is (= [1 2] (seq (array :ndarray [1 2]))))
   )
 
+(deftest test-slice-on-1d
+  (is (scalar? (slice (array :ndarray [1 2 3]) 0))))
+
 (deftest test-assign
   (let [m (empty-ndarray [2 2 2])
         vm [[[0 1] [2 3]] [[4 5] [6 7]]]]


### PR DESCRIPTION
Fixed slice behaviour on 1d-arrays 
- in the default implementation
- for NDArray 
- added tests for it
- enforce it with tests in compliance test
  Build currently fails as the vectorz implementation also shows the bug. See https://github.com/mikera/vectorz/issues/21
