### PR TITLE
Bugfix for ndarray (mmul 1D-vector 1D-vector) plus test for this case.

### DIFF
--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -535,6 +535,10 @@
   (test-numeric-instance (matrix im [1 2 -3 4.5 7 -10.8]))
   (test-numeric-instance (matrix im [0 0])))
 
+(defn test-1d-mmul [im]
+  (let [m (matrix im [1 2 3])]
+    (is (equals 14 (mmul m m)))))
+
 (defn vector-tests-1d [im]
   (test-vector-mset im)
   (test-vector-length im)
@@ -545,7 +549,8 @@
   (test-vector-subvector im)
   (test-vector-distance im)
   (test-element-add im)
-  (test-1d-instances im))
+  (test-1d-instances im)
+  (test-1d-mmul im))
 
 ;; ========================================
 ;; 2D matrix tests

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
@@ -795,6 +795,8 @@
              ^ints b-shape (.shape b)]
          (cond
           (== b-ndims 0) (mp/scale a b)
+          (and (== a-ndims 1) (== b-ndims 1))
+          (mp/inner-product a b)
           (and (== a-ndims 1) (== b-ndims 2))
           (let [b-rows (aget b-shape (int 0))]
             (mp/reshape (mp/matrix-multiply (mp/reshape a [1 b-rows]) b)


### PR DESCRIPTION
This is a fix for issue #145, ndarray mmul on two vectors returns nil.
