### PR TITLE
e== bug related to equality dependence on order of args fixed

### DIFF
--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -673,6 +673,17 @@
     (set-column! mutable-m 0 7)
     (is (equals [[7 2] [7 4]] mutable-m))))
 
+(defn test-matrix-equals
+  [im]
+  (let [m1 (matrix im [[1 2] [3 4]])
+        m2 [[1 2] [3 4]]
+        m3 (matrix im [[1 2 3 4]])
+        m4 [1 2 3 4]]
+    (is (e== m1 m2))
+    (is (e== m2 m1))
+    (is (e== m3 m4))
+    (is (e== m4 m3))))
+
 
 (defn matrix-tests-2d [im]
   (test-row-column-matrices im)

--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -912,14 +912,20 @@
           (if (== 0 (mp/dimensionality a))
             (== (mp/get-0d a) (scalar-coerce b))
             (not (some false? (map == (mp/element-seq a) (mp/element-seq b)))))
+        (and (== (mp/dimensionality a) 1)
+             (== (mp/dimensionality b) 2))
+          (mp/matrix-equals (mp/row-matrix a a) b)
+        (and (== (mp/dimensionality a) 2)
+             (== (mp/dimensionality b) 1))
+          (mp/matrix-equals a (mp/row-matrix b b))
         :else false)))
 
 (extend-protocol mp/PValueEquality
   nil
     (value-equals [a b]
-      (or 
+      (or
         (nil? b)
-        (and 
+        (and
           (== 0 (mp/dimensionality b))
           (nil? (mp/get-0d b)))))
   Object

--- a/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
@@ -333,16 +333,22 @@
     (matrix-equals [a b]
       (let [bdims (long (mp/dimensionality b))]
         (cond
-          (<= bdims 0) 
+          (<= bdims 0)
             false
-          (not= (count a) (mp/dimension-count b 0)) 
+          (and (= (mp/dimensionality a) 1)
+               (= (mp/dimensionality b) 2))
+            (mp/matrix-equals (mp/row-matrix a a) b)
+          (and (= (mp/dimensionality a) 2)
+               (= (mp/dimensionality b) 1))
+            (mp/matrix-equals a (mp/row-matrix b b))
+          (not= (count a) (mp/dimension-count b 0))
             false
           (== 1 bdims)
             (and (== 1 (mp/dimensionality a))
                  (let [n (long (count a))]
                    (loop [i 0]
                      (if (< i n)
-                       (if (== (mp/get-1d a i) (mp/get-1d b i)) 
+                       (if (== (mp/get-1d a i) (mp/get-1d b i))
                          (recur (inc i))
                          false)
                        true))))

--- a/src/test/clojure/clojure/core/matrix/properties.clj
+++ b/src/test/clojure/clojure/core/matrix/properties.clj
@@ -15,13 +15,13 @@
 ;; This constant defines a number of tests for each of properties
 
 (def num-tests 100)
-
+(def impls [:ndarray :persistent-vector :vectorz :object-array :double-array])
 ;; # Helpers
 ;;
 ;; ## Generators
 
 (def gen-impl
-  (gen/elements [:ndarray :persistent-vector :vectorz :object-array :double-array]))
+  (gen/elements impls))
 
 ;; TODO: n should be generated as well
 (defn gen-vec-mtx [n]
@@ -93,6 +93,14 @@
            #_(proper-array? vec-mtx)
            (= arr-shape (shape vec-arr))
            (= arr-shape (shape arr))))))
+
+;; Check that equal matrices of different implementations are considered equal
+(defspec matrix-equals num-tests
+  (prop/for-all
+   [mtx (gen-matrix)]
+   (let [mtxs (map #(matrix % mtx) impls)]
+     (for [m1 mtxs m2 mtxs]
+       (e== m1 m2)))))
 
 (defspec householder-matrix-props num-tests
   (prop/for-all [;; shrinking of keywords is broken in current simple-check


### PR DESCRIPTION
Bug demo:

``` Clojure
user=> m1
[6.0 15.0 24.0 33.0]
user=> m2
 A 1x4 matrix
 -------------
 6.00e+00  1.50e+01  2.40e+01  3.30e+01

user=> (e== m1 m2)
false
user=> (e== m2 m1)
true
```
