### PR TITLE
transposed matrix coerced to the input matrix type

### DIFF
--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -580,7 +580,9 @@
   (testing "2D transpose"
     (let [m (matrix im [[1 2] [3 4]])]
       (is (equals [[1 3] [2 4]] (transpose m)))
-      (is (equals m (transpose (transpose m)))))))
+      (is (equals m (transpose (transpose m))))
+      (is (= (imp/get-canonical-object m)
+             (imp/get-canonical-object (transpose m)))))))
 
 (defn test-order [im]
   (testing "order"

--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -513,18 +513,20 @@
     (transpose [m] m)
   Object
     (transpose [m]
-      (case (long (mp/dimensionality m))
-        0 m
-        1 m
-        2 (apply mapv vector (map
+      (mp/coerce-param
+       m
+       (case (long (mp/dimensionality m))
+         0 m
+         1 m
+         2 (apply mapv vector (map
                                #(mp/convert-to-nested-vectors %)
                                (mp/get-major-slice-seq m)))
-        (let [ss (map mp/transpose (mp/get-major-slice-seq m))]
-          ;; note that function must come second for mp/element-map
-          (case (count ss)
-            1 (mp/element-map (mp/convert-to-nested-vectors (first ss)) vector)
-            2 (mp/element-map (mp/convert-to-nested-vectors (first ss)) vector (second ss))
-            (mp/element-map (mp/convert-to-nested-vectors (first ss)) vector (second ss) (nnext ss)))))))
+         (let [ss (map mp/transpose (mp/get-major-slice-seq m))]
+           ;; note that function must come second for mp/element-map
+           (case (count ss)
+             1 (mp/element-map (mp/convert-to-nested-vectors (first ss)) vector)
+             2 (mp/element-map (mp/convert-to-nested-vectors (first ss)) vector (second ss))
+             (mp/element-map (mp/convert-to-nested-vectors (first ss)) vector (second ss) (nnext ss))))))))
 
 (extend-protocol mp/PTransposeInPlace
   Object

--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -1708,7 +1708,8 @@
         (aset us i (aget qr-data qr-idx))
         (recur (+ qr-idx mcols)
                (inc i)))))
-  (let [max_ (apply max (map #(Math/abs ^Double %) us))]
+  (let [max_ (apply max (map #(Math/abs ^Double %)
+                             (mp/subvector us idx (- mrows idx))))]
     (if (= max_ 0.0)
       {:error true}
       (let [_ (c-for [i idx (< i mrows) (inc i)]


### PR DESCRIPTION
Bug example:

``` Clojure
user=> (def m (matrix :clatrix [[1 2 3]
  #_=>                          [4 5 6]
  #_=>                          [7 8 9]]))
#'user/m
user=> m
 A 3x3 matrix
 -------------
 1.00e+00  2.00e+00  3.00e+00
 4.00e+00  5.00e+00  6.00e+00
 7.00e+00  8.00e+00  9.00e+00
user=> (transpose m)
[[1.0 4.0 7.0] [2.0 5.0 8.0] [3.0 6.0 9.0]]
```
