### PR TITLE
bug in mmul of vector and matrix fixed

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -636,7 +636,7 @@
          (and (== mdims 1) (== adims 2))
            (let [[arows acols] (mp/get-shape a)]
              (mp/reshape (mp/matrix-multiply (mp/reshape m [1 arows]) a)
-                         [arows]))
+                         [acols]))
          (and (== mdims 2) (== adims 1))
            (let [[mrows mcols] (mp/get-shape m)]
              (mp/reshape (mp/matrix-multiply m (mp/reshape a [mcols 1]))

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
@@ -796,9 +796,10 @@
           (and (== a-ndims 1) (== b-ndims 1))
           (mp/inner-product a b)
           (and (== a-ndims 1) (== b-ndims 2))
-          (let [b-rows (aget b-shape (int 0))]
+          (let [b-rows (aget b-shape (int 0))
+                b-cols (aget b-shape (int 1))]
             (mp/reshape (mp/matrix-multiply (mp/reshape a [1 b-rows]) b)
-                        [b-rows]))
+                        [b-cols]))
           (and (== a-ndims 2) (== b-ndims 1))
           (let [a-cols (aget shape (int 1))
                 a-rows (aget shape (int 0))]


### PR DESCRIPTION
Currently, reshaping of matrices does not work properly for NDArray. Example:

``` Clojure
user=> (def Y (matrix [1 0 0 0 0]))
#'user/Y
user=> (def P (matrix [[0 2 0 0 0 0 0] [1 0 0 0 0 0 0] [0 0 0 0 0 0 0] [0 0 0 0 0 0 0] [0 0 0 0 0 0 0]]))
#'user/P
user=> (m/shape Y)
[5]
user=> (m/shape P)
[5 7]
user=> (m/mmul Y P)
#<NDArray [0.0 2.0 0.0 0.0 0.0]>
user=> (m/shape (m/mmul Y P))
[5]
```

After applying PR:

``` Clojure
user=> (def Y (matrix [1 0 0 0 0]))
#'user/Y
user=> (def P (matrix [[0 2 0 0 0 0 0] [1 0 0 0 0 0 0] [0 0 0 0 0 0 0] [0 0 0 0 0 0 0] [0 0 0 0 0 0 0]]))
#'user/P
user=> (m/shape Y)
[5]
user=> (m/shape P)
[5 7]
user=> (m/mmul Y P)
#<NDArray [0.0 2.0 0.0 0.0 0.0 0.0 0.0]>
user=> (m/shape (m/mmul Y P))
[7]
```
