### PR TITLE
new-matrix bug with dataset implementation fixed

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/dataset.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/dataset.clj
@@ -53,9 +53,10 @@
     (meta-info [m]
       {:doc "Clojure.core.matrix implementation for datasets"})
     (new-vector [m length] (error "Can't construct a Dataset as a 1D vector, only 2D supported"))
-    (new-matrix [m rows columns] 
-      (let [col-indexes (range columns)] 
-        (dataset (mapv keyword col-indexes) (for [i col-indexes] (mp/new-vector @#'clojure.core.matrix/*matrix-implementation* rows)))))
+    (new-matrix [m rows columns]
+      (let [col-indexes (range columns)]
+        (dataset (mapv (comp keyword str) col-indexes)
+                 (for [i col-indexes] (mp/new-vector @#'clojure.core.matrix/*matrix-implementation* rows)))))
     (new-matrix-nd [m shape]
       (if (== 2 (count shape))
         (mp/new-matrix m (first shape) (second shape))

--- a/src/main/clojure/clojure/core/matrix/impl/dataset.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/dataset.clj
@@ -55,7 +55,7 @@
     (new-vector [m length] (error "Can't construct a Dataset as a 1D vector, only 2D supported"))
     (new-matrix [m rows columns]
       (let [col-indexes (range columns)]
-        (dataset (mapv (comp keyword str) col-indexes)
+        (dataset col-indexes
                  (for [i col-indexes] (mp/new-vector @#'clojure.core.matrix/*matrix-implementation* rows)))))
     (new-matrix-nd [m shape]
       (if (== 2 (count shape))


### PR DESCRIPTION
Bug:

``` Clojure
user=> (new-matrix :dataset 3 4)
#clojure.core.matrix.impl.dataset.DataSet{:column-names [nil nil nil nil], :columns [[0.0 0.0 0.0] [0.0 0.0 0.0] [0.0 0.0 0.0] [0.0 0.0 0.0]]}
```

After applying PR:

``` Clojure
user=> (new-matrix :dataset 3 4)
#clojure.core.matrix.impl.dataset.DataSet{:column-names [:0 :1 :2 :3], :columns [[0.0 0.0 0.0] [0.0 0.0 0.0] [0.0 0.0 0.0] [0.0 0.0 0.0]]}
```
