### PR TITLE
linear.qr returns [:Q, :R] by default

### DIFF
--- a/src/main/clojure/clojure/core/matrix/linear.clj
+++ b/src/main/clojure/clojure/core/matrix/linear.clj
@@ -33,14 +33,20 @@
     - Q is an orthogonal matrix
     - R is an upper triangular matrix (= right triangular matrix)
    If :return parameter is specified in options map, it returns only specified keys.
+   If :compact parameter is specified in options map, compact versions of matrices are returned.
 
    Returns nil if decomposition is impossible.
 
    Intended usage: (let [{:keys [Q R]} (qr M)] ....)
                    (let [{:keys [R]} (qr M {:return [:R]})] ....)"
 
-  ([m options] (mp/qr m options))
-  ([m] (qr m {:return [:Q :R]})))
+  ([m {:keys [return compact]
+       :or {return [:Q :R]
+            compact false}}]
+     (mp/qr m {:return return
+               :compact compact}))
+  ([m]
+     (mp/qr m {:return [:Q :R]})))
 
 (defn cholesky
   "Computes the Cholesky decomposition of a hermitian, positive definite matrix.


### PR DESCRIPTION
Currently, if `compact` option is specified, but `return` option is not, empty result is always returned.

Example of current behavior:

``` Clojure
user=> (def m (matrix [[1 2 3] [4 5 6] [7 8 9]]))
user=> (qr m {:compact true})
{}
```

Example of PR fix:

``` Clojure
user=> (def m (matrix [[1 2 3] [4 5 6] [7 8 9]]))
user=> (qr m {:compact true})
:R [[-8.12403840463596 -9.601136296387953 -11.078234188139945] [0 0.9045340337332906 1.809068067466581] [0 0 -6.661338147750939E-16]], :Q [[-0.12309149097933259 0.9045340337332904 -0.4082482904638633] [-0.49236596391733084 0.30151134457776413 0.8164965809277258] [-0.8616404368553291 -0.30151134457776385 -0.4082482904638628]]}
```
