### PR TITLE
diagonal-matrix now returns matrix of current implementation

### DIFF
--- a/src/main/clojure/clojure/core/matrix.clj
+++ b/src/main/clojure/clojure/core/matrix.clj
@@ -271,7 +271,7 @@
    Diagonal matrices constructed this way may use specialised storage formats, hence may not be fully mutable.
    Use (mutable (diagonal-matrix ...)) if you need to guarantee a mutable matrix."
   ([diagonal-values]
-    (mp/diagonal-matrix (current-implementation-object) diagonal-values))
+    (mp/diagonal-matrix (implementation-check) diagonal-values))
   ([implementation diagonal-values]
     (mp/diagonal-matrix (imp/get-canonical-object implementation) diagonal-values)))
 


### PR DESCRIPTION
Currently, there is a bug:

``` Clojure
user=> (set-current-implementation :ndarray)
:ndarray
user=> (diagonal-matrix [1 1 1])
[[1 0.0 0.0] [0.0 1 0.0] [0.0 0.0 1]]
```

PR fix:

``` Clojure
user=> (set-current-implementation :ndarray)
:ndarray
user=>  (diagonal-matrix [1 1 1])
#<NDArray [[1 0 0] [0 1 0] [0 0 1]]>
```
