### PR TITLE
Join-along implementation

### DIFF
--- a/src/main/clojure/clojure/core/matrix.clj
+++ b/src/main/clojure/clojure/core/matrix.clj
@@ -926,9 +926,11 @@
 (defn join-along
   "Joins arrays together, along a specified dimension. Other dimensions must be compatible."
   ([dimension & arrays]
-    (if (== 0 dimension)
-      (apply join arrays)
-      (TODO))))
+   (if (== 0 dimension)
+     (apply join arrays)
+     (mapv (fn [i]
+             (apply join (map #(mp/get-slice % (dec dimension) i) arrays)))
+           (range (dimension-count (first arrays) (dec dimension)))))))
 
 (defn rotate
   "Rotates an array along specified dimensions."

--- a/src/main/clojure/clojure/core/matrix.clj
+++ b/src/main/clojure/clojure/core/matrix.clj
@@ -926,11 +926,15 @@
 (defn join-along
   "Joins arrays together, along a specified dimension. Other dimensions must be compatible."
   ([dimension & arrays]
+   (assert (< dimension (dimensionality (first arrays)))
+           "Specifified dimension incompatible with first array's dimensionality")
    (if (== 0 dimension)
      (apply join arrays)
-     (mapv (fn [i]
-             (apply join (map #(mp/get-slice % (dec dimension) i) arrays)))
-           (range (dimension-count (first arrays) (dec dimension)))))))
+     (let [partial-join (partial join-along (- dimension 1))]
+       (mapv (fn [i]
+               (apply partial-join
+                      (map #(mp/get-slice % (dec dimension) i) arrays)))
+             (range (dimension-count (first arrays) (dec dimension))))))))
 
 (defn rotate
   "Rotates an array along specified dimensions."

--- a/src/main/clojure/clojure/core/matrix.clj
+++ b/src/main/clojure/clojure/core/matrix.clj
@@ -928,6 +928,8 @@
   ([dimension & arrays]
    (assert (< dimension (dimensionality (first arrays)))
            "Specifified dimension incompatible with first array's dimensionality")
+   (assert (or (== 0 dimension) (== 1 dimension))
+           "Only joining along the first or second dimension is supported")
    (if (== 0 dimension)
      (apply join arrays)
      (let [partial-join (partial join-along (dec dimension))]

--- a/src/main/clojure/clojure/core/matrix.clj
+++ b/src/main/clojure/clojure/core/matrix.clj
@@ -926,8 +926,6 @@
 (defn join-along
   "Joins arrays together, along a specified dimension. Other dimensions must be compatible."
   ([dimension & arrays]
-   (assert (< dimension (dimensionality (first arrays)))
-           "Specifified dimension incompatible with first array's dimensionality")
    (assert (or (== 0 dimension) (== 1 dimension))
            "Only joining along the first or second dimension is supported")
    (if (== 0 dimension)

--- a/src/main/clojure/clojure/core/matrix.clj
+++ b/src/main/clojure/clojure/core/matrix.clj
@@ -930,11 +930,9 @@
            "Specifified dimension incompatible with first array's dimensionality")
    (if (== 0 dimension)
      (apply join arrays)
-     (let [partial-join (partial join-along (- dimension 1))]
-       (mapv (fn [i]
-               (apply partial-join
-                      (map #(mp/get-slice % (dec dimension) i) arrays)))
-             (range (dimension-count (first arrays) (dec dimension))))))))
+     (let [partial-join (partial join-along (dec dimension))]
+       (apply mapv partial-join
+             (map (fn [a] (mp/get-slice-seq a (dec dimension))) arrays))))))
 
 (defn rotate
   "Rotates an array along specified dimensions."

--- a/src/test/clojure/clojure/core/matrix/test_api.clj
+++ b/src/test/clojure/clojure/core/matrix/test_api.clj
@@ -384,6 +384,12 @@
   (is (= [1 2 3] (join [1 2] 3)))
   (is (= [[1 1] [2 2] [3 3]] (join [[1 1]] [[2 2] [3 3]]))))
 
+(deftest test-join-along
+  (is (= [1 2 3] (join-along 0 [1 2] [3])))
+  (is (= [3 1 2] (join-along 0 [3] [1 2])))
+  (is (= [[3 2 1] [1 2 3]] (join-along 1 [[3 2] [1 2]] [[1] [3]])))
+  (is (= [[1 3 2] [3 1 2]] (join-along 1 [[1] [3]] [[3 2] [1 2]]))))
+
 (deftest test-main-diagonal
   (is (e== [1 2] (main-diagonal [[1 0] [4 2] [5 7]])))
   (is (e== [1 4] (diagonal [[1 2] [3 4]]))))


### PR DESCRIPTION
I was needing the ability to join two 2-D matrices the other day and noticed it had not been implemented yet.

I spend some time implementing something that worked for that case and wanted to see if it would be useful to incorporate.

A couple things:
1. It does not work on 3+ dimensions. I have an assert to prevent that. I assume the final join-along implementation will support that, but in the meantime this works for 2.
2. I started to add a compliance test. But then I noticed the the current join is set to test if the matrix has a dimension less than 0. When would that ever happen? It seems to me that the current join compliance test never runs. And when I set to to run with dimension == 1, there are many failures. Is this is a known issue for further improvement? 

If you are interested in my join-along implementation. And can let me know what is going on with the join compliance test, I can add a join-along compliance test.
