### PR TITLE
check for column-names uniqueness added

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/dataset.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/dataset.clj
@@ -17,6 +17,8 @@
   (let [^IPersistentVector col-names (vec col-names)
         ^IPersistentVector columns (vec columns)
         cc (count col-names)]
+    (when (not= cc (count (into #{} col-names)))
+      (error "DataSet does not support duplicate column names"))
     (when (not= cc (count columns))
       (error "Mismatched number of columns, have: " cc " column names"))
     (DataSet. col-names columns)))


### PR DESCRIPTION
Currently, you can do:

``` Clojure
user=> (dataset [:c :c] [[1 2 3] [4 5 6]])
#clojure.core.matrix.impl.dataset.DataSet{:column-names [:c :c], :columns [[1 2 3] [4 5 6]]}
```

After PR:

``` Clojure
user=> (dataset [:c :c] [[1 2 3] [4 5 6]])
RuntimeException DataSet does not support duplicate column names  clojure.core.matrix.impl.dataset/construct-dataset (dataset.clj:21)
```
