### PR TITLE
dataset get-rows bug fixed

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/dataset.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/dataset.clj
@@ -69,7 +69,8 @@
 (extend-protocol mp/PMatrixRows
   DataSet
   (get-rows [ds]
-    (mp/transpose (mp/get-columns ds))))
+    (map #(mp/get-row ds %)
+         (range (mp/dimension-count ds 0)))))
 
 (extend-protocol mp/PColumnSetting
   DataSet


### PR DESCRIPTION
Example of the bug:

``` Clojure
user=> (def dataset-1 (dataset [:a_number :a_blob]
  #_=>                         [[java.lang.Math/PI  (byte-array (. "a big blob" getBytes))]
  #_=>                          [2.0 (byte-array (take 4097 (cycle (. "one zero" getBytes))))]]))
#'user/dataset-1
user=> (rows dataset-1)

RuntimeException Can't convert to persistent vector array: inconsistent shape.  clojure.core.matrix.impl.persistent-vector/eval7052/fn--7053 (persistent_vector.clj:481)
```

After fix:

``` Clojure
user=> (rows dataset-1)
(#<SliceWrapper [3.141592653589793 [97 32 98 105 103 32 98 108 111 98]]> #<SliceWrapper [2.0 [111 110 101 32 122 101 114 111 111 110 101 32 122 101...)
```
