### PR TITLE
Dataset fixes

### DIFF
--- a/src/main/clojure/clojure/core/matrix/dataset.clj
+++ b/src/main/clojure/clojure/core/matrix/dataset.clj
@@ -5,6 +5,11 @@
   (:require [clojure.core.matrix.protocols :as mp])
   (:import clojure.core.matrix.impl.dataset.DataSet))
 
+(defmacro dataset?
+  "Returns true if argument is a dataset"
+  ([d]
+     `(instance? DataSet ~d)))
+
 (defn dataset
   "Creates dataset from:
     column names and seq of rows
@@ -23,6 +28,7 @@
       :else (error "Don't know how to create dataset from shape"  (shape m))))
   ([m]
      (cond
+      (dataset? m) m
       (matrix? m) (dataset-from-array m)
       (map? m)
       (let [col-names (keys m)

--- a/src/main/clojure/clojure/core/matrix/impl/dataset.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/dataset.clj
@@ -98,14 +98,17 @@
                " not found in dataset"))))
   (select-rows [ds rows]
     (let [col-names (mp/column-names ds)
-          row-maps (mp/row-maps ds)
-          c (count (mp/get-rows ds))
-          out-of-range (filter #(>= % c) rows)]
-      (if (= (count out-of-range) 0)
+          row-maps (mp/row-maps ds)]
+      (try
         (->> (map #(nth row-maps %) rows)
              (dataset-from-row-maps col-names))
-        (error "Dataset contains only " c " rows. Can't select rows with indices: "
-               (vec out-of-range)))))
+        (catch Exception e
+          (let [c (count (mp/get-rows ds))
+                out-of-range (filter #(>= % c) rows)]
+            (if (> (count out-of-range) 0)
+              (error "Dataset contains only " c " rows. Can't select rows with indices: "
+                     (vec out-of-range))
+              (throw e)))))))
   (add-column [ds col-name col]
     (dataset-from-columns (conj (mp/column-names ds) col-name)
                           (conj (mp/get-columns ds) col)))


### PR DESCRIPTION
There 2 fixes:
- If dataset instance is passed into dataset constructor, it returns this argument. Example (with pretty-print from `Incanter`)
  Now:

``` Clojure
user=> d1
#clojure.core.matrix.impl.dataset.DataSet{:column-names [:a :b :c], :columns [[1 4] [2 5] [3 6]]}
user=> (dataset d1)
#clojure.core.matrix.impl.dataset.DataSet{:column-names [0 1 2], :columns [[1 4] [2 5] [3 6]]}
```

With PR:

``` Clojure
user=> d1
#clojure.core.matrix.impl.dataset.DataSet{:column-names [:a :b :c], :columns [[1 4] [2 5] [3 6]]}

user=> (dataset d1)
#clojure.core.matrix.impl.dataset.DataSet{:column-names [:a :b :c], :columns [[1 4] [2 5] [3 6]]}
```
- Check for rows out of range in `select-rows` happens only if exception is caught.
