### PR TITLE
broken commit url fixed

### DIFF
--- a/src/dev/clojure/clojure/core/matrix/docgen/implementations.clj
+++ b/src/dev/clojure/clojure/core/matrix/docgen/implementations.clj
@@ -18,7 +18,7 @@
   [git-hash]
   (seq [[:h2 "Protocol/Implementation summary"]
         [:p "git hash: "
-         [:a {:href (str repo-url "/blob/" git-hash)}
+         [:a {:href (str repo-url "/tree/" git-hash)}
           git-hash]]
         [:small "Hint: hover on protocol or implementation names to "
          "get their description"]]))


### PR DESCRIPTION
http://mikera.github.io/core.matrix/summary.html
Current url in the head leads to [404](https://github.com/mikera/core.matrix/blob/dc0f3d66ad7c48493f4110fc15621a7d0f817647)
With this fix it will lead to https://github.com/mikera/core.matrix/tree/dc0f3d66ad7c48493f4110fc15621a7d0f817647
