### PR TITLE
The default implementation of PTypeInfo now checks whether an object is ...

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -779,7 +779,9 @@
       java.lang.Object)
   Object
     (element-type [a]
-      java.lang.Object))
+      (if (java-array? a)
+        (.getComponentType (class a))
+        java.lang.Object)))
 
 ;; generic element values
 (extend-protocol mp/PGenericValues


### PR DESCRIPTION
...a Java array and will return its component type if true.

This is a rather naive attempt, but I don't think there is another way to do this for arrays with arbitrary component types.

Notice that I do not check for arrays of arrays here. 

By the way, I've signed the Clojure CA, but I my name isn't on the website yet.
