### PR TITLE
Faster NDArray loading

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,16 +8,16 @@
   :url "https://github.com/mikera/matrix-api"
   :license {:name "Eclipse Public License (EPL)"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  
+
   :source-paths ["src/main/clojure"]
   :java-source-paths ["src/test/java"]
-  
+
   :test-paths ["src/test/clojure" "src/test/java"]
-  
+
   :dependencies [[org.clojure/clojure "1.6.0"]]
-  
+
   :marginalia {:javascript ["http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"]}
-  
+
   :profiles {:dev {:dependencies [[net.mikera/cljunit "0.3.1"]
                                   [com.google.caliper/caliper "0.5-rc1"]
                                   [criterium/criterium "0.4.3"]
@@ -26,4 +26,7 @@
                                   [net.mikera/vectorz-clj "0.25.0"]
                                   [org.clojure/test.check "0.5.9"]]
                    :source-paths ["src/main/clojure" "src/dev/clojure"]
-                   :jvm-opts ^:replace []}})
+                   :jvm-opts ^:replace []}}
+
+  :aot [clojure.core.matrix.impl.ndarray-double
+        clojure.core.matrix.impl.ndarray-object])

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
@@ -625,12 +625,12 @@
   ;;   (broadcast [m target-shape])
   ;; mp/PBroadcastLike
   ;;   (broadcast-like [m a])
-  
+
   mp/PBroadcastCoerce
     (broadcast-coerce [m a]
       (let [^typename# a (if (instance? typename# a) a (mp/coerce-param m a))]
         (mp/broadcast-like m a)))
-  
+
   ;; mp/PReshaping
   ;;   (reshape [m shape])
 
@@ -1177,5 +1177,3 @@
       (iae-when-not (== (aget shape 0) (aget shape 1))
         "inverse operates only on square matrices")
       (invert#t m)))
-
-(magic/spit-code)

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray_double.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray_double.clj
@@ -1,0 +1,15 @@
+(ns clojure.core.matrix.impl.ndarray-double
+  (:require [clojure.walk :as w])
+  (:use clojure.core.matrix.utils)
+  (:use clojure.core.matrix.impl.ndarray-macro)
+  (:require [clojure.core.matrix.impl.default])
+  (:require [clojure.core.matrix.impl.ndarray-magic :as magic])
+  (:require [clojure.core.matrix.protocols :as mp])
+  (:require [clojure.core.matrix.implementations :as imp])
+  (:require [clojure.core.matrix.impl.mathsops :as mops])
+  (:require [clojure.core.matrix.multimethods :as mm])
+  (:refer-clojure :exclude [vector?])
+
+  (:use clojure.core.matrix.impl.ndarray))
+
+(magic/spit-code :double)

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray_magic.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray_magic.clj
@@ -141,8 +141,13 @@
    `test-ndarray-implementation` namespace"
   [type & body]
   (let [replaces (form-replaces {} type)
+        class-suffix (if-let [fn-suffix (->> type type-table-magic :fn-suffix)]
+                 (str "_" (name fn-suffix))
+                 "")
         replaces (assoc replaces
                    'typename#
-                   (symbol (str "clojure.core.matrix.impl.ndarray."
+                   (symbol (str "clojure.core.matrix.impl.ndarray"
+                                class-suffix
+                                "."
                                 (get replaces 'typename#))))]
     `(do ~@(handle-forms type replaces body))))

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray_object.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray_object.clj
@@ -1,0 +1,15 @@
+(ns clojure.core.matrix.impl.ndarray-object
+  (:require [clojure.walk :as w])
+  (:use clojure.core.matrix.utils)
+  (:use clojure.core.matrix.impl.ndarray-macro)
+  (:require [clojure.core.matrix.impl.default])
+  (:require [clojure.core.matrix.impl.ndarray-magic :as magic])
+  (:require [clojure.core.matrix.protocols :as mp])
+  (:require [clojure.core.matrix.implementations :as imp])
+  (:require [clojure.core.matrix.impl.mathsops :as mops])
+  (:require [clojure.core.matrix.multimethods :as mm])
+  (:refer-clojure :exclude [vector?])
+
+  (:use clojure.core.matrix.impl.ndarray))
+
+(magic/spit-code :object)

--- a/src/main/clojure/clojure/core/matrix/implementations.clj
+++ b/src/main/clojure/clojure/core/matrix/implementations.clj
@@ -12,8 +12,8 @@
 (def KNOWN-IMPLEMENTATIONS
   (array-map
    :vectorz 'mikera.vectorz.matrix-api
-   :ndarray 'clojure.core.matrix.impl.ndarray
-   :ndarray-double 'clojure.core.matrix.impl.ndarray
+   :ndarray 'clojure.core.matrix.impl.ndarray-object
+   :ndarray-double 'clojure.core.matrix.impl.ndarray-double
    :ndarray-float 'clojure.core.matrix.impl.ndarray
    :ndarray-long 'clojure.core.matrix.impl.ndarray
    :persistent-vector 'clojure.core.matrix.impl.persistent-vector
@@ -46,7 +46,7 @@
 (defn get-implementation-key
   "Returns the implementation code for a given object"
   ([m]
-    (cond 
+    (cond
       (keyword? m) m
       (mp/is-scalar? m) nil
       :else (mp/implementation-key m))))
@@ -63,28 +63,28 @@
   ([k]
     (if-let [ns-sym (KNOWN-IMPLEMENTATIONS k)]
       (try
-        (do 
-          (require ns-sym) 
+        (do
+          (require ns-sym)
           (if (@canonical-objects k) :ok :warning-implementation-not-registered?))
         (catch Throwable t nil)))))
 
 (defn get-canonical-object
   "Gets the canonical object for a specific implementation. The canonical object is used
-   to call implementation-specific protocol functions where required (e.g. creation of new 
+   to call implementation-specific protocol functions where required (e.g. creation of new
    arrays of the correct type for the implementation)"
   ([]
     (get-canonical-object *matrix-implementation*))
   ([m]
     (let [k (get-implementation-key m)
           obj (@canonical-objects k)]
-      (if k 
+      (if k
         (or obj
            (if (try-load-implementation k) (@canonical-objects k))
            (when-not (keyword? m) m)
            (error "Unable to find implementation: [" k "]"))
         nil))))
 
-(defn construct 
+(defn construct
   "Attempts to construct an array according to the type of array m. If not possible,
    returns another array type."
   ([m data]

--- a/src/test/clojure/clojure/core/matrix/test_ndarray_implementation.clj
+++ b/src/test/clojure/clojure/core/matrix/test_ndarray_implementation.clj
@@ -9,7 +9,9 @@
   (:require [clojure.core.matrix.impl.ndarray])
   (:require [clojure.core.matrix.impl.ndarray-magic :as magic])
   (:require [clojure.core.matrix.impl.ndarray-macro :as macro])
-  (:use clojure.core.matrix.impl.ndarray))
+  (:use clojure.core.matrix.impl.ndarray)
+  (:use clojure.core.matrix.impl.ndarray-double)
+  (:use clojure.core.matrix.impl.ndarray-object))
 
 ;; Tests for the NDArray implementation
 
@@ -77,7 +79,7 @@
       (is (== 10 (ereduce + m)))
       (is (== 4 (ereduce (fn [acc _] (inc acc)) 0 m)))
       (is (== 4 (ereduce (fn [acc _] (inc acc)) 0 (eseq m))))))
-  
+
   (testing "Elementwise divide"
     (is (equals [2 2] (div (array :ndarray [6 4]) [3 2])))))
 
@@ -106,7 +108,7 @@
   (let [a (array :ndarray [[1 2] [3 4]])]
     (is (equals [[9 9] [9 9]] (fill a 9)))
     (is (equals [[9 9] [9 9]] (fill a [9 9])))
-    (is (equals [[1 2] [3 4]] a)))) 
+    (is (equals [[1 2] [3 4]] a))))
 
 (deftest test-contained-vectors
   (let [a (array :ndarray :foo)]
@@ -171,7 +173,7 @@
                first
                (mget 1))))
   (is (equals [10] (add-product! (array :ndarray [4]) [2] [3])))
-  (is (equals [30 70 110] (mmul (array :ndarray-double [[1 2 3 4] [5 6 7 8] [9 10 11 12]]) [1 2 3 4]))) 
+  (is (equals [30 70 110] (mmul (array :ndarray-double [[1 2 3 4] [5 6 7 8] [9 10 11 12]]) [1 2 3 4])))
   (is (equals [10] (add-product (array :ndarray [4]) [2] [3]))))
 
 (deftest ndarray-test


### PR DESCRIPTION
I've tried to find a bottleneck that slows down NDArray loading/compilation, but traces didn't show anything specific, just a lot of work by compiler. This can be reasonable given that after inlining/specialization NDArray is about 150kb of code (per type). The patch does two things:
- specialized versions of NDArray now live in separate namespaces. This helps by allowing to compile only the code that is needed.
- I've added AOT compilation of those namespaces into project.clj, this clearly helps:

```
user=> (require '[clojure.core.matrix :as m])
nil
user=> (time (m/matrix :ndarray-double [[1 2] [3 4]]))
"Elapsed time: 396.013099 msecs"
#<NDArrayDouble [[1.0 2.0] [3.0 4.0]]>
```

If you are aware of downsides of AOTing those, please tell me.

In future code size can be significantly reduced by de-inlining `loop-over` macro and turning it into a type-specialized function. I don't know how big performance impact will be, but there will be some.
