### PR TITLE
Add codox documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.classpath
 /.settings
 /classes
+/doc
 
 .lein-*
 

--- a/project.clj
+++ b/project.clj
@@ -25,8 +25,15 @@
                                   [hiccup "1.0.5"]
                                   [net.mikera/vectorz-clj "0.26.0"]
                                   [org.clojure/test.check "0.5.9"]]
+
                    :source-paths ["src/main/clojure" "src/dev/clojure"]
-                   :jvm-opts ^:replace []}}
+                   :jvm-opts ^:replace []}
+             :doc {:plugins [[codox "0.8.8"]]}}
+  :aliases {"doc" ["with-profile" "doc" "doc"]}
+  :codox {:sources ["src/main/clojure"]
+          :src-dir-uri "https://github.com/mikera/core.matrix/blob/master/"
+          :src-linenum-anchor-prefix "L"
+          :exclude clojure.core.matrix.examples}
 
   :aot [clojure.core.matrix.impl.ndarray-double
         clojure.core.matrix.impl.ndarray-object])


### PR DESCRIPTION
You generate the docs by running `lein doc`. To push them to GitHub, follow the instructions at https://github.com/weavejester/codox/wiki/Deploying-to-GitHub-Pages

Fixes #208.

I made a new profile for this because of https://github.com/weavejester/codox/issues/58
