### PR TITLE
Clean up ns declarations, more idiomatic code

### DIFF
--- a/src/dev/clojure/clojure/core/matrix/docgen/bench.clj
+++ b/src/dev/clojure/clojure/core/matrix/docgen/bench.clj
@@ -1,15 +1,10 @@
 (ns clojure.core.matrix.docgen.bench
-  (:use [clojure.core.matrix.docgen.bench-suite])
   (:require [criterium.core :as cr]
-            [clojure.string :as s]
             [hiccup.page :as h]
             [clojure.core.matrix :as m]
-            [clojure.core.matrix.utils :as utils]
-            [clojure.core.matrix.protocols :as mp]
-            [clojure.core.matrix.implementations :as imp]
-            [clojure.core.matrix.multimethods :as mm]
-            [clojure.core.matrix.implementations :as mi]
-            [clojure.core.matrix.impl.common :as c]))
+            [clojure.core.matrix.utils :as u]
+            [clojure.core.matrix.impl.common :as c]
+            [clojure.core.matrix.docgen.bench-suite :refer :all]))
 
 ;; # Constants
 
@@ -194,7 +189,7 @@
                               first)]))))))
 
 (defn perform-bench []
-  (doseq [proto (utils/extract-protocols)]
+  (doseq [proto (u/extract-protocols)]
     (doseq [[_ {f-name :name}] (:sigs proto)
             :let [f-name-kw (keyword f-name)]]
       (doseq [[a-type a-info] array-types]
@@ -227,7 +222,7 @@
 
 (defn generate []
   (let [git-hash (c/get-git-hash)
-        protos (utils/extract-protocols)
+        protos (u/extract-protocols)
         header (render-header git-hash)
         table (render-table protos)]
     (render-page header table)))

--- a/src/dev/clojure/clojure/core/matrix/docgen/implementations.clj
+++ b/src/dev/clojure/clojure/core/matrix/docgen/implementations.clj
@@ -1,9 +1,8 @@
 (ns clojure.core.matrix.docgen.implementations
   (:require [clojure.string :as s]
             [hiccup.page :as h]
-            [clojure.core.matrix.utils :as utils]
+            [clojure.core.matrix.utils :as u]
             [clojure.core.matrix.protocols :as mp]
-            [clojure.core.matrix.implementations :as mi]
             [clojure.core.matrix.impl.common :as c]))
 
 ;; ## Info
@@ -73,7 +72,7 @@
 (defn generate
   []
   (let [impl-objs (c/get-impl-objs)
-        protos (c/extract-implementations (utils/extract-protocols) impl-objs)
+        protos (c/extract-implementations (u/extract-protocols) impl-objs)
         git-hash (c/get-git-hash)
         header (render-header git-hash)
         table (render-table impl-objs protos git-hash)]

--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -1,12 +1,13 @@
 (ns clojure.core.matrix.compliance-tester
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.linear)
-  (:use clojure.test)
-  (:require [clojure.core.matrix.operators :as ops])
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.generic :as generic])
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.utils :as utils :refer [error error?]]))
+  (:require [clojure.core.matrix.operators :as ops]
+            [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.generic :as generic]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.impl.persistent-vector :as pvector]
+            [clojure.core.matrix.utils :as u :refer [error error?]]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.linear :refer :all]
+            [clojure.test :refer :all]))
 
 ;; ====================================
 ;; COMPLIANCE TESTING
@@ -48,7 +49,7 @@
   "Creates a set of vector matrices of supported dimensionalities from 1 to 4"
   ([m]
     (map
-      #(create-dimensioned %)
+      create-dimensioned
       (filter #(supports-dimensionality? m %)
               (range 1 5)))))
 
@@ -93,7 +94,7 @@
   (testing "shape"
     (let [sh (shape m)
           dims (dimensionality m)]
-      (is (utils/valid-shape? sh))
+      (is (u/valid-shape? sh))
       (is (== (count sh) dims))
       (is (= (seq sh) ;; we need the seqs to account for empty shapes (need to comapre equal to nil)
              (seq (for [i (range dims)] (dimension-count m i)))))))
@@ -140,16 +141,16 @@
               (is (equals v1 (apply mget m ix)))
               (is (equals v2 (apply mget cm ix))))))
   (testing "attempt to modify an immutable array results in an exception"
-    (when (not (mutable? m))
-            (let [cm (clone m)
-                  ix (first (index-seq m))
-                  v1 (first (eseq m))
-                  v2 (if (and (number? v1) (== v1 0)) 1 0)]
-              (is (thrown? Throwable (apply mset! cm (concat ix [v2]))))))))
+    (when-not (mutable? m)
+      (let [cm (clone m)
+            ix (first (index-seq m))
+            v1 (first (eseq m))
+            v2 (if (and (number? v1) (== v1 0)) 1 0)]
+        (is (thrown? Throwable (apply mset! cm (concat ix [v2]))))))))
 
 (defn test-reshape [m]
   (let [c (ecount m)]
-    (when (> c 0)
+    (when (pos? c)
       (when (supports-dimensionality? m 1)
         (= (eseq m) (eseq (reshape m [c]))))
       (when (supports-dimensionality? m 2)
@@ -158,14 +159,14 @@
 
 (defn test-broadcast [m]
   (let [c (ecount m)]
-    (when (> c 0)
+    (when (pos? c)
       (e= m (first (slices (broadcast m (cons 2 (shape m))))))
       (== c (ecount (broadcast m (cons 1 (shape m)))))
       (== (* 3 c) (ecount (broadcast m (cons 3 (shape m))))))))
 
 (defn test-slice-assumptions [m]
   (let [dims (dimensionality m)]
-    (when (> dims 0) ;; slices only valid for dimensionality 1 or above
+    (when (pos? dims) ;; slices only valid for dimensionality 1 or above
       (let [slcs (slices m)]
         (doseq [sl slcs]
           (is (== (dec dims) (dimensionality sl)))
@@ -177,7 +178,7 @@
           (is (e= m slcs)))))))
 
 (defn test-slice-returns-scalar-on-1d [m]
-  (when (and (= 1 (dimensionality m)) (> (ecount m) 0))
+  (when (and (= 1 (dimensionality m)) (pos? (ecount m)))
     (is (scalar? (slice m 0)))))
 
 (defn test-submatrix-assumptions [m]
@@ -190,7 +191,7 @@
     ))
 
 (defn test-general-transpose [m]
-  (when (> (ecount m) 0)
+  (when (pos? (ecount m))
     (let [mt (transpose m)]
       (is (e= m (transpose mt)))
       (is (= (seq (shape m))
@@ -210,7 +211,7 @@
   ;; (is (identical? m (coerce m m))) ;; TODO: figure out if we should enforce this?
   (let [vm (mp/convert-to-nested-vectors m)]
     (is (or (clojure.core/vector? vm) (== 0 (mp/dimensionality vm))))
-    (is (clojure.core.matrix.impl.persistent-vector/is-nested-persistent-vectors? vm))
+    (is (pvector/is-nested-persistent-vectors? vm))
     (is (e= m vm))))
 
 (defn test-pack [m]
@@ -230,7 +231,7 @@
     (is (e= (reshape av (shape m)) m))))
 
 (defn test-assign [m]
-  (when (and m (> (ecount m) 0)) ;; guard for nil and empty arrays
+  (when (and m (pos? (ecount m))) ;; guard for nil and empty arrays
     (let [e (first (eseq m))
           n (assign m e)
           mm (mutable-matrix m)]
@@ -246,7 +247,7 @@
         os (slices original dim)
         cnt (dimension-count original dim)]
     (is (== (dimension-count joined dim) (* 2 cnt)))
-    (when (> cnt 0)
+    (when (pos? cnt)
       (is (e= os (take cnt js)))
       (is (e= os (drop cnt js))))))
 
@@ -272,11 +273,11 @@
 (defn test-pm
   "Test for matrix pretty-printing"
   ([m]
-    (is (< 0 (count (with-out-str (pm m)))))))
+    (is (pos? (count (with-out-str (pm m)))))))
 
 (defn test-to-string [m]
   (when m ;; guard for nil
-    (is (string? (.toString m)))))
+    (is (string? (str m)))))
 
 (defn test-elements [m]
   (let [es (eseq m)]
@@ -335,7 +336,7 @@
       (let [v (matrix im [1])]
         (is (== 1.0 (mget v 0))))
       (let [a (new-array im [1])]
-        (is (= (mget a 0) (clojure.core.matrix.generic/default-value im))))))
+        (is (= (mget a 0) (generic/default-value im))))))
   (testing "Matrix construction"
     (when (supports-dimensionality? im 2)
       (let [m (matrix im [[1 2] [3 4]])]
@@ -392,7 +393,7 @@
            :slice-wrapper
            :scalar-wrapper} im-name)
       true
-      (doseq [proto (utils/extract-protocols)]
+      (doseq [proto (u/extract-protocols)]
         (doseq [[_ {:keys [name arglists]}] (:sigs proto)
                 :let [method (ns-resolve 'clojure.core.matrix.protocols
                                          name)]]

--- a/src/main/clojure/clojure/core/matrix/dataset.clj
+++ b/src/main/clojure/clojure/core/matrix/dataset.clj
@@ -1,9 +1,9 @@
 (ns clojure.core.matrix.dataset
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.impl.dataset)
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:import clojure.core.matrix.impl.dataset.DataSet))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.impl.dataset :as impl]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.utils :refer [error]])
+  (:import [clojure.core.matrix.impl.dataset DataSet]))
 
 (defmacro dataset?
   "Returns true if argument is a dataset"
@@ -19,18 +19,18 @@
     seq of maps"
   ([col-names data]
      (cond
-      (matrix? data) (dataset-from-rows col-names data)
-      (and (vec? data) (empty? data)) (dataset-from-rows col-names data)
-      (map? (first data)) (dataset-from-row-maps col-names data)
+      (matrix? data) (impl/dataset-from-rows col-names data)
+      (and (vec? data) (empty? data)) (impl/dataset-from-rows col-names data)
+      (map? (first data)) (impl/dataset-from-row-maps col-names data)
       (map? data) (let [cols (reduce
                            (fn [acc c] (conj acc (get data c)))
                            [] col-names)]
-                 (dataset-from-columns col-names cols))
+                 (impl/dataset-from-columns col-names cols))
       :else (error "Don't know how to create dataset from shape"  (shape data))))
   ([data]
      (cond
       (dataset? data) data
-      (matrix? data) (dataset-from-array data)
+      (matrix? data) (impl/dataset-from-array data)
       (map? data)
       (let [col-names (keys data)
             cols (reduce
@@ -38,7 +38,7 @@
                   [] col-names)
             row-counts (into #{} (map count data))]
         (if (= (count row-counts) 1)
-          (dataset-from-columns col-names cols)
+          (impl/dataset-from-columns col-names cols)
           (error "Cant' create dataset with different column lengths")))
 
       (and (= (mp/dimensionality data) 1)
@@ -58,7 +58,7 @@
                       (into #{})
                       (count)
                       (= 1)))
-          (dataset-from-columns
+          (impl/dataset-from-columns
            col-names
            (reduce #(conj %1 (get col-map %2)) [] col-names))
           (error "Can't create dataset from incomplete maps"))))))

--- a/src/main/clojure/clojure/core/matrix/examples.clj
+++ b/src/main/clojure/clojure/core/matrix/examples.clj
@@ -1,7 +1,7 @@
 (ns clojure.core.matrix.examples
   (:refer-clojure :exclude [* - + == /])
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.operators))
+  (:require [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.operators :refer :all]))
 
 ;; =============================================================
 ;; Set of clojure.core.matrix examples

--- a/src/main/clojure/clojure/core/matrix/experimental.clj
+++ b/src/main/clojure/clojure/core/matrix/experimental.clj
@@ -1,5 +1,4 @@
 (ns clojure.core.matrix.experimental
-  (:use clojure.core.matrix)
   (:require [clojure.core.matrix.protocols :as mp]))
 
 ;; Namespace for experimental functions and macros, building on core.matrix
@@ -15,7 +14,7 @@
          (range ~(first shape)))
       `(do ~@body))))
 
-(defn raw-shape 
+(defn raw-shape
   "Returns the raw shape of a matrix. May be any type that suports seq, including Java arrays.
    The advantage of this methods is that it avoids converting the shape to a Clojure vector
    (the behaviour of shape)."

--- a/src/main/clojure/clojure/core/matrix/generic.clj
+++ b/src/main/clojure/clojure/core/matrix/generic.clj
@@ -1,7 +1,7 @@
 (ns clojure.core.matrix.generic
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.implementations :as imp]))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.utils :refer [TODO]]))
 
 ;; Placeholder namespace for generic versions of core.matrix algorithms
 
@@ -23,7 +23,7 @@
 
 (defn two
   "Returns the standard 'two' scalar value for the given array / implementation"
-  ([impl] 
+  ([impl]
     (let [o (one impl)]
       (mp/get-0d (mp/matrix-add o o)))))
 

--- a/src/main/clojure/clojure/core/matrix/impl/common.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/common.clj
@@ -1,12 +1,8 @@
 (ns clojure.core.matrix.impl.common
-  (:use [clojure.java.shell :only [sh]])
-  (:require [clojure.reflect :as r]
-            [clojure.string :as s]
-            [clojure.core.matrix.protocols :as mp]
-            [clojure.core.matrix.utils :as utils]
-            [clojure.core.matrix.implementations :as imp]
-            [clojure.core.matrix.multimethods :as mm]
-            [clojure.core.matrix.implementations :as mi]))
+  (:require [clojure.string :as s]
+            [clojure.core.matrix.utils :as u]
+            [clojure.core.matrix.implementations :as mi]
+            [clojure.java.shell :refer [sh]]))
 
 (defn get-impl-objs
   "Returns a list of available implementations' objects"
@@ -23,7 +19,7 @@
    support provided protocol"
   [protocol impl-objs]
   (->> impl-objs
-       (filter #(->> % :obj class (utils/extends-deep? protocol)))
+       (filter #(->> % :obj class (u/extends-deep? protocol)))
        (map :name)
        (into #{})))
 

--- a/src/main/clojure/clojure/core/matrix/impl/dataset.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/dataset.clj
@@ -1,8 +1,8 @@
 (ns clojure.core.matrix.impl.dataset
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.impl.wrappers :as wrap])
-  (:require [clojure.core.matrix.protocols :as mp])
+  (:require [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.impl.wrappers :as wrap]
+            [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.utils :refer :all])
   (:import [clojure.lang IPersistentVector]))
 
 ;; TODO
@@ -168,7 +168,7 @@
     (let [col-set-1 (into #{} (mp/column-names ds1))
           col-set-2 (into #{} (mp/column-names ds2))
           intersection (clojure.set/intersection col-set-1 col-set-2)]
-      (if (= (count intersection) 0)
+      (if (zero? (count intersection))
         (dataset-from-columns
          (concat (mp/column-names ds1) (mp/column-names ds2))
          (concat (mp/get-columns ds1) (mp/get-columns ds2)))

--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -1,15 +1,16 @@
 (ns clojure.core.matrix.impl.default
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.impl.double-array])
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.impl.wrappers :as wrap])
-  (:require [clojure.core.matrix.multimethods :as mm])
-  (:require [clojure.core.matrix.impl.mathsops :as mops])
-  (:require [clojure.core.matrix.implementations :as imp]))
+  (:require [clojure.core.matrix.impl.double-array :as da]
+            [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.impl.wrappers :as wrap]
+            [clojure.core.matrix.multimethods :as mm]
+            [clojure.core.matrix.impl.mathsops :as mops]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.utils :refer :all])
+  (:import [clojure.lang ISeq]))
 
 ;; =========================================================================
 ;; This namespace contains default implementations for core.matrix protocols
-;; 
+;;
 ;; These will be used for any protocol that is not extended to an array type
 ;;
 ;; In general, default implementations are provided for:
@@ -54,7 +55,7 @@
         (== dims 0)
           (wrap/wrap-scalar (mp/get-0d m))
         (and (== dims 1) double?)
-          (clojure.core.matrix.impl.double-array/construct-double-array m)
+          (da/construct-double-array m)
         double?
           (mp/coerce-param (imp/get-canonical-object :ndarray-double) m)
         :else
@@ -74,7 +75,7 @@
   Object
     (implementation-key [m] :default)
     (meta-info [m] {})
-    (construct-matrix [m data] 
+    (construct-matrix [m data]
       (mp/construct-matrix [] data))
     (new-vector [m length]
       (mp/new-vector [] length))
@@ -95,7 +96,7 @@
     (sparse-coerce [m data]
       nil) ;; allow fall through if sparse coercion is not directly supported
     (sparse [m]
-      m)) 
+      m))
 
 (extend-protocol mp/PDense
   nil
@@ -107,7 +108,7 @@
     (dense-coerce [m data]
       nil) ;; allow fall-through if dense coercion is not directly supported
     (dense [m]
-      m)) 
+      m))
 
 ;; default implementation for matrix ops
 
@@ -131,11 +132,11 @@
         (error "Can't do ND get on a scalar number with indexes: " s)
         m))
   Object
-    (get-1d [m x] 
+    (get-1d [m x]
       (cond
         (java-array? m) (mp/get-0d (nth m x))
         :else (mp/get-nd m [x])))
-    (get-2d [m x y] 
+    (get-2d [m x y]
       (cond
         (java-array? m) (mp/get-1d (nth m x) y)
         :else (mp/get-nd m [x y])))
@@ -152,7 +153,7 @@
   Number
     (nonzero-count [m] (if (zero? m) 0 1))
   Object
-    (nonzero-count [m] 
+    (nonzero-count [m]
       (mp/element-reduce m (fn [cnt e] (if (zero? e) cnt (inc cnt))) 0)))
 
 (extend-protocol mp/PZeroDimensionConstruction
@@ -191,31 +192,31 @@
   Object
     (set-0d [m value]
       value ;; should be OK, since scalars satisfy 0d array abstraction
-      )) 
+      ))
 
 (extend-protocol mp/PIndexedSetting
-  nil 
+  nil
     (set-1d [m row v]
       (error "Can't do 1D set on nil"))
     (set-2d [m row column v]
       (error "Can't do 2D set on nil"))
     (set-nd [m indexes v]
-      (if (seq indexes) 
+      (if (seq indexes)
         (error "Can't do " (count indexes) "D set on nil")
         v))
     (is-mutable? [m]
       false)
-  Number 
+  Number
     (set-1d [m row v]
       (error "Can't do 1D set on a scalar number"))
     (set-2d [m row column v]
       (error "Can't do 2D set on a scalar number"))
     (set-nd [m indexes v]
-      (if (seq indexes) 
+      (if (seq indexes)
         (error "Can't do " (count indexes) "D set on a scalar number")
         v))
     (is-mutable? [m]
-      false) 
+      false)
   Object
     (set-1d [m row v]
       (let [m (mp/clone m)]
@@ -308,14 +309,14 @@
       (let [dims (long (mp/dimensionality m))]
         (cond
           (== 0 dims) (mp/set-0d! m (mp/get-0d x))
-          (== 1 dims) 
-            (if (instance? clojure.lang.ISeq x)
+          (== 1 dims)
+            (if (instance? ISeq x)
               (let [x (seq x)
                     msize (long (mp/dimension-count m 0))]
                 (loop [i 0 s (seq x)]
                   (if (>= i msize)
                     (when s (error "Mismatches size of sequence in assign!"))
-                    (do 
+                    (do
                       (mp/set-1d! m i (first s))
                       (recur (inc i) (next s))))))
              (let [xdims (long (mp/dimensionality x))
@@ -324,11 +325,11 @@
                   (let [value (mp/get-0d x)]
                     (dotimes [i msize] (mp/set-1d! m i value)))
                   (dotimes [i msize] (mp/set-1d! m i (mp/get-1d x i))))))
-          
-              
+
+
           (array? m)
             (let [xdims (long (mp/dimensionality x))]
-              (if (> xdims 0)
+              (if (pos? xdims)
                 (let [xss (mp/get-major-slice-seq x)
                       _ (or (mp/same-shapes? xss) (error "Inconsistent slice shapes for assign!"))]
                   (doall (map (fn [a b] (mp/assign! a b)) (mp/get-major-slice-seq m) xss)))
@@ -389,14 +390,14 @@
   nil
     (immutable-matrix [m]
       nil)
-  Object 
+  Object
     (immutable-matrix [m]
-      (if (mp/is-mutable? m) 
+      (if (mp/is-mutable? m)
         (mp/convert-to-nested-vectors m)
-        m))) 
+        m)))
 
 (extend-protocol mp/PZeroCount
-  nil 
+  nil
     (zero-count [m]
       0)
   Number
@@ -438,29 +439,29 @@
     (get-shape [m] nil)
     (dimension-count [m i] (error "Number has zero dimensionality, cannot get count for dimension: " i))
   Object
-    (dimensionality [m] 
-      (cond 
-        (.isArray (.getClass m)) 
+    (dimensionality [m]
+      (cond
+        (.isArray (.getClass m))
           (let [n (count m)]
             (if (> n 0) (inc (mp/dimensionality (nth m 0))) 1))
         :else 0))
-    (is-vector? [m] 
-      (cond 
-        (.isArray (.getClass m)) 
+    (is-vector? [m]
+      (cond
+        (.isArray (.getClass m))
           (let [n (count m)]
             (or (== n 0) (== 0 (mp/dimensionality (nth m 0)))))
         :else false))
-    (is-scalar? [m] 
+    (is-scalar? [m]
       (cond
         (.isArray (.getClass m)) false
         :else true)) ;; assume objects are scalars unless told otherwise
-    (get-shape [m] 
+    (get-shape [m]
       (cond
-        (.isArray (.getClass m)) 
+        (.isArray (.getClass m))
           (let [n (count m)]
-            (if (== n 0) [0] (cons n (mp/get-shape (nth m 0))))) 
+            (if (== n 0) [0] (cons n (mp/get-shape (nth m 0)))))
         :else nil))
-    (dimension-count [m i] 
+    (dimension-count [m i]
       (cond
         (.isArray (.getClass m))
           (if (== i 0) (count m) (mp/dimension-count (nth m 0) (dec i)))
@@ -472,7 +473,7 @@
   nil
     (same-shape? [a b]
       (== 0 (mp/dimensionality b)))
-  Number 
+  Number
     (same-shape? [a b]
       (== 0 (mp/dimensionality b)))
   Object
@@ -543,13 +544,13 @@
     (rotate [m dim places] m)
   Object
     (rotate [m dim places]
-      (cond 
+      (cond
         (<= (mp/dimensionality m) 0)
           m
         (== 0 dim)
           (let [ss (mp/get-major-slice-seq m)
                 c (long (mp/dimension-count m 0))
-                sh (long (if (> c 0) (long (mod places c)) 0))]
+                sh (long (if (pos? c) (long (mod places c)) 0))]
             (if (== sh 0)
               m
               (vec (concat (take-last (- c sh) ss) (take sh ss)))))
@@ -563,9 +564,9 @@
   Number
     (rotate-all [m shifts] m)
   Object
-    (rotate-all [m shifts] 
-      (reduce (fn [m [dim shift]] (mp/rotate m dim shift)) 
-         m 
+    (rotate-all [m shifts]
+      (reduce (fn [m [dim shift]] (mp/rotate m dim shift))
+         m
          (map-indexed (fn [i v] [i v]) shifts))))
 
 (extend-protocol mp/POrder
@@ -713,13 +714,13 @@
     (element-min [m] m)
     (element-max [m] m)
   Object
-    (element-min [m] 
-      (mp/element-reduce m 
-                       (fn [best v] (if (or (not best) (< v best)) v best)) 
+    (element-min [m]
+      (mp/element-reduce m
+                       (fn [best v] (if (or (not best) (< v best)) v best))
                        nil))
-    (element-max [m] 
-      (mp/element-reduce m 
-                       (fn [best v] (if (or (not best) (> v best)) v best)) 
+    (element-max [m]
+      (mp/element-reduce m
+                       (fn [best v] (if (or (not best) (> v best)) v best))
                        nil)))
 
 ;; add-product operations
@@ -776,28 +777,28 @@
 (extend-protocol mp/PTypeInfo
   nil
     (element-type [a]
-      java.lang.Object)
+      Object)
   Object
     (element-type [a]
       (if (java-array? a)
         (.getComponentType (class a))
-        java.lang.Object)))
+        Object)))
 
 ;; generic element values
 (extend-protocol mp/PGenericValues
   Object
-    (generic-zero [m] 
+    (generic-zero [m]
        0)
-    (generic-one [m] 
+    (generic-one [m]
        1)
-    (generic-value [m] 
+    (generic-value [m]
        nil)
   Object
-    (generic-zero [m] 
+    (generic-zero [m]
        0)
-    (generic-one [m] 
+    (generic-one [m]
       1)
-    (generic-value [m] 
+    (generic-value [m]
       0))
 
 ;; general transformation of a vector
@@ -913,15 +914,15 @@
         (mp/same-shape? a b)
           (if (== 0 (mp/dimensionality a))
             (== (mp/get-0d a) (scalar-coerce b))
-            (not (some false? (map == (mp/element-seq a) (mp/element-seq b)))))
+            (not-any? false? (map == (mp/element-seq a) (mp/element-seq b))))
         :else false)))
 
 (extend-protocol mp/PValueEquality
   nil
     (value-equals [a b]
-      (or 
+      (or
         (nil? b)
-        (and 
+        (and
           (== 0 (mp/dimensionality b))
           (nil? (mp/get-0d b)))))
   Object
@@ -955,7 +956,7 @@
 
 (extend-protocol mp/PDoubleArrayOutput
   Number
-    (to-double-array [m] 
+    (to-double-array [m]
       (let [arr (double-array 1)] (aset arr 0 (double m)) arr))
     (as-double-array [m] nil)
   Object
@@ -965,11 +966,11 @@
 
 (extend-protocol mp/PObjectArrayOutput
   nil
-    (to-object-array [m] 
+    (to-object-array [m]
       (let [arr (object-array 1)] arr))
     (as-object-array [m] nil)
   Number
-    (to-object-array [m] 
+    (to-object-array [m]
       (let [arr (object-array 1)] (aset arr 0 m) arr))
     (as-object-array [m] nil)
   Object
@@ -1049,7 +1050,7 @@
           (== 0 dims)
             (list (mp/get-0d m))
           (and (.isArray c) (.isPrimitive (.getComponentType c)))
-            (seq m)            
+            (seq m)
           (== 1 dims)
             (map #(mp/get-1d m %) (range (mp/dimension-count m 0)))
           (array? m)
@@ -1106,8 +1107,8 @@
 (extend-protocol mp/PElementCount
   nil (element-count [m] 1)
   Number (element-count [m] 1)
-  Object 
-    (element-count [m] (if (array? m) 
+  Object
+    (element-count [m] (if (array? m)
                          (calc-element-count m)
                          1)))
 
@@ -1120,11 +1121,11 @@
       (cond
         (== 0 (mp/dimensionality m))
           (if (mp/is-scalar? m) nil [])
-        :else 
+        :else
           (let [shapes (map mp/validate-shape (mp/get-major-slice-seq m))]
             (if (mp/same-shapes? shapes)
               (cons (mp/dimension-count m 0) (first shapes))
-              (error "Inconsistent shapes for sub arrays in " (class m))))))) 
+              (error "Inconsistent shapes for sub arrays in " (class m)))))))
 
 
 (extend-protocol mp/PMatrixSlices
@@ -1136,13 +1137,13 @@
     (get-column [m i]
       (mp/get-slice m 1 i))
     (get-major-slice [m i]
-      (cond 
+      (cond
        (java-array? m) (nth m i)
        (== 1 (mp/dimensionality m)) (mp/get-1d m i)
         :else (clojure.core.matrix.impl.wrappers/wrap-slice m i)))
     (get-slice [m dimension i]
       (cond
-        (< dimension 0) (error "Can't take slice on negative dimension: " dimension)
+        (neg? dimension) (error "Can't take slice on negative dimension: " dimension)
         (== 0 dimension) (mp/get-major-slice m i)
         :else (mp/get-slice (mp/convert-to-nested-vectors m) dimension i))))
 
@@ -1167,9 +1168,9 @@
 (extend-protocol mp/PSliceView
   Object
     ;; default implementation uses a lightweight wrapper object
-    (get-major-slice-view [m i] 
+    (get-major-slice-view [m i]
       (cond
-        (java-array? m) 
+        (java-array? m)
           (let [ss (nth m i)]
             (if (array? ss)
               ss
@@ -1182,28 +1183,28 @@
       (let [dims (long (mp/dimensionality m))]
         (cond
           (<= dims 0) (error "Can't get slices on [" dims "]-dimensional object")
-          (.isArray (.getClass m)) (seq m) 
+          (.isArray (.getClass m)) (seq m)
           (== dims 1) (map #(mp/get-1d m %) (range (mp/dimension-count m 0)))
           :else (map #(mp/get-major-slice m %) (range (mp/dimension-count m 0)))))))
 
 (extend-protocol mp/PSliceSeq2
   Object
     (get-slice-seq [m dimension]
-      (cond 
+      (cond
         (== dimension 0) (mp/get-major-slice-seq m)
         (< dimension 0) (error "Can't get slices of a negative dimension: " dimension)
         :else (map #(mp/get-slice m dimension %) (range (mp/dimension-count m dimension))))))
 
 (extend-protocol mp/PSliceViewSeq
   Object
-    (get-major-slice-view-seq [m] 
+    (get-major-slice-view-seq [m]
       (let [n (mp/dimension-count m 0)]
         (for [i (range n)]
           (mp/get-major-slice-view m i)))))
 
 (extend-protocol mp/PSliceJoin
   nil
-    (join [m a] 
+    (join [m a]
       (error "Can't join an array to a nil value!"))
   Number
     (join [m a]
@@ -1264,12 +1265,12 @@
         m))
   Object
     (submatrix [m index-ranges]
-      (clojure.core.matrix.impl.wrappers/wrap-submatrix m index-ranges)))
+      (wrap/wrap-submatrix m index-ranges)))
 
 (extend-protocol mp/PBroadcast
   nil
     (broadcast [m new-shape]
-      (clojure.core.matrix.impl.wrappers/wrap-broadcast m new-shape))
+      (wrap/wrap-broadcast m new-shape))
 ; TODO: efficient way to use current implementation?
 ;  Number
 ;    (broadcast [m new-shape]
@@ -1287,16 +1288,16 @@
           ;(and (> ndims mdims) (== mshape (drop (- ndims mdims) nshape)))
           ;  (let [rep (nth nshape (- ndims mdims 1))]
           ;    (mp/broadcast (vec (repeat rep m)) new-shape))
-          :else (clojure.core.matrix.impl.wrappers/wrap-broadcast m new-shape)))))
+          :else (wrap/wrap-broadcast m new-shape)))))
 
 (extend-protocol mp/PBroadcastLike
   nil
     (broadcast-like [m a]
-      (clojure.core.matrix.impl.wrappers/wrap-broadcast a (mp/get-shape m)))
+      (wrap/wrap-broadcast a (mp/get-shape m)))
   Object
     (broadcast-like [m a]
       (let [sm (mp/get-shape m) sa (mp/get-shape a)]
-        (if (clojure.core.matrix.utils/same-shape-object? sm sa)
+        (if (same-shape-object? sm sa)
           a
           (mp/broadcast a sm)))))
 
@@ -1331,7 +1332,7 @@
         (cond
           (== dims 0)
               (mp/get-0d m)
-          (== 1 dims)             
+          (== 1 dims)
             (if (or (seq? m) (sequential? m))
               (mapv mp/get-0d m)
               (let [n (long (mp/dimension-count m 0))]
@@ -1353,14 +1354,14 @@
     (column-matrix [m data] (error "Can't create a column matrix from nil"))
     (row-matrix [m data] (error "Can't create a column matrix from nil"))
   Object
-    (column-matrix [m data] 
+    (column-matrix [m data]
       (if (== 1 (mp/dimensionality data))
         (mp/coerce-param m (mapv vector (mp/element-seq data)))
         (error "Can't create a column matrix: input must be 1D vector")))
-    (row-matrix [m data] 
+    (row-matrix [m data]
       (if (== 1 (mp/dimensionality data))
         (mp/coerce-param m (vector data))
-        (error "Can't create a row matrix: input must be 1D vector")))) 
+        (error "Can't create a row matrix: input must be 1D vector"))))
 
 (extend-protocol mp/PVectorView
   nil
@@ -1435,9 +1436,9 @@
   Object
     (coerce-param [m param]
       ;; NOTE: leave param unchanged if coercion not possible (probably an invalid shape for implementation)
-      (let [param (if (instance? clojure.lang.ISeq param) (mp/convert-to-nested-vectors param) param)] ;; ISeqs can be slow, so convert to vectors
-        (or (mp/construct-matrix m param) 
-           param)))) 
+      (let [param (if (instance? ISeq param) (mp/convert-to-nested-vectors param) param)] ;; ISeqs can be slow, so convert to vectors
+        (or (mp/construct-matrix m param)
+           param))))
 
 (extend-protocol mp/PExponent
   Number
@@ -1539,10 +1540,10 @@
   [m]
   (let [dim (first (mp/get-shape m))]
     (letfn [(f [i j]
-              (cond 
+              (cond
                 (>= i dim) true                         ; all entries match: symmetric
                 (>= j dim) (recur (+ 1 i) (+ 2 i))      ; all j's OK: restart with new i
-                (= (mp/get-2d m i j) 
+                (= (mp/get-2d m i j)
                    (mp/get-2d m j i)) (recur i (inc j)) ; OK, so check next pair
                 :else false))]                          ; not same, not symmetric
       (f 0 1))))
@@ -1602,15 +1603,15 @@
           values (mp/element-seq (mp/broadcast values [(count indices)]))]
       (loop [[id & idx] indices [v & vs] values]
         (when id
-          (do (mp/set-nd! a id v) (recur idx vs)))))))
+          (mp/set-nd! a id v) (recur idx vs))))))
 
 (extend-protocol mp/PNonZeroIndices
   Object
-  (non-zero-indices 
+  (non-zero-indices
     [m]
     (if (mp/is-vector? m)
       (vec (for [i (range (mp/dimension-count m 0))
-                    :when (not (== 0 (mp/get-1d m i)))] 
+                    :when (not (== 0 (mp/get-1d m i)))]
               i))
       (vec (for [i (range (mp/dimension-count m 0))]
               (mp/non-zero-indices (mp/get-major-slice m i)))))))
@@ -1627,7 +1628,7 @@
              (every? (fn [[i j v]]
                        (cond
                         (= i j) true
-                        (and (not (= i j)) (== v 0)) true
+                        (and (not= i j) (== v 0)) true
                         :else false)))))
       false))
   (upper-triangular? [m]
@@ -1707,15 +1708,15 @@
 
 (extend-protocol mp/PDimensionImplementation
   Object
-    (dimension-name [ds idx dim] 
-      (cond 
+    (dimension-name [ds idx dim]
+      (cond
         (== dim 0) (mp/row-name ds idx)
         (== dim 1) (mp/column-name ds idx)
         :else idx))
-    (row-name [ds idx] 
+    (row-name [ds idx]
       idx)
-    (column-name [ds idx] 
-      (nth (mp/column-names ds) idx)))  
+    (column-name [ds idx]
+      (nth (mp/column-names ds) idx)))
 
 ;; =======================================================
 ;; default linear algebra implementations
@@ -1724,7 +1725,7 @@
   Object
   (norm [m p]
     (cond
-      (= p java.lang.Double/POSITIVE_INFINITY) (mp/element-max m)
+      (= p Double/POSITIVE_INFINITY) (mp/element-max m)
       (number? p) (mp/element-sum (mp/element-pow (mp/element-map m mops/abs) p))
       :else (error "p must be a number"))))
 
@@ -1792,11 +1793,10 @@
                       mrows ^doubles us ^doubles gammas]
   (loop [qr-idx (+ idx (* idx mcols))
          i idx]
-    (if (< i mrows)
-      (do
-        (aset us i (aget qr-data qr-idx))
-        (recur (+ qr-idx mcols)
-               (inc i)))))
+    (when (< i mrows)
+      (aset us i (aget qr-data qr-idx))
+      (recur (+ qr-idx mcols)
+             (inc i))))
   (let [max_ (apply max (map #(Math/abs ^Double %)
                              (mp/subvector us idx (- mrows idx))))]
     (if (= max_ 0.0)
@@ -1850,8 +1850,7 @@
                           idx+1
                           (- j idx+1))]
             (aset qr-data qr-idx
-                  (-> (aget qr-data qr-idx)
-                      (- (* u (aget vs j)))))))))
+                  (- (aget qr-data qr-idx) (* u (aget vs j))))))))
 
     (when (< idx mcols)
       (aset qr-data (+ idx (* idx mcols)) (double (- tau))))
@@ -1900,7 +1899,7 @@
 ;; temp var to prevent recursive coercion if implementation does not support liear algebra operation
 (def ^:dynamic *trying-current-implementation* nil)
 
-(defmacro try-current-implementation 
+(defmacro try-current-implementation
   [sym form]
   `(if *trying-current-implementation*
      (TODO (str "Not yet implemented: " ~(str form) " for " (class ~sym)))
@@ -1911,32 +1910,32 @@
 
 (extend-protocol mp/PCholeskyDecomposition
   Object
-  (cholesky [m options] 
+  (cholesky [m options]
     (try-current-implementation m (mp/cholesky m options))))
 
 (extend-protocol mp/PLUDecomposition
   Object
-  (lu [m options] 
+  (lu [m options]
     (try-current-implementation m (mp/lu m options))))
 
 (extend-protocol mp/PSVDDecomposition
   Object
-  (svd [m options] 
+  (svd [m options]
     (try-current-implementation m (mp/svd m options))))
 
 (extend-protocol mp/PEigenDecomposition
   Object
-  (eigen [m options] 
+  (eigen [m options]
     (try-current-implementation m (mp/eigen m options))))
 
 (extend-protocol mp/PSolveLinear
   Object
-  (solve [a b] 
+  (solve [a b]
     (try-current-implementation a (mp/solve a b))))
 
 (extend-protocol mp/PLeastSquares
   Object
-  (least-squares [a b] 
+  (least-squares [a b]
     (try-current-implementation a (mp/least-squares a b))))
 
 ;; =======================================================

--- a/src/main/clojure/clojure/core/matrix/impl/double_array.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/double_array.clj
@@ -1,10 +1,7 @@
 (ns clojure.core.matrix.impl.double-array
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:use clojure.core.matrix.utils)
-  (:require clojure.core.matrix.impl.persistent-vector)
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.impl.mathsops :as mops])
-  (:require [clojure.core.matrix.multimethods :as mm]))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.utils :refer :all]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* true)
@@ -15,7 +12,7 @@
 
 (def ^:const DOUBLE-ARRAY-CLASS (Class/forName "[D"))
 
-(def array-magic-data 
+(def array-magic-data
   {:double {:class DOUBLE-ARRAY-CLASS
             :regname :ndarray-double
             :fn-suffix 'double
@@ -177,13 +174,13 @@
 
 (extend-protocol mp/PVectorOps
   (Class/forName "[D")
-    (vector-dot [a b] 
+    (vector-dot [a b]
       (cond
         (is-double-array? b)
           (let [^doubles a a
                 ^doubles b b
                 n (alength a)]
-            (when (not (== n (alength b))) (error "Incompatible double array lengths"))
+            (when-not (== n (alength b)) (error "Incompatible double array lengths"))
             (loop [i 0 res 0.0]
               (if (< i n)
                 (recur (inc i) (+ res (* (aget a i) (aget b i))))
@@ -198,13 +195,13 @@
                 res)))
         :else nil))
     (length [a] (Math/sqrt (doubles-squared-sum a)))
-    (length-squared [a] 
+    (length-squared [a]
       (doubles-squared-sum a))
     (normalise [a]
       (let [a ^doubles a
             len (doubles-squared-sum a)]
         (cond
-          (> len 0.0) (mp/scale a (/ 1.0 (Math/sqrt len))) 
+          (> len 0.0) (mp/scale a (/ 1.0 (Math/sqrt len)))
           :else (double-array (alength a))))))
 
 (extend-protocol mp/PCoercion

--- a/src/main/clojure/clojure/core/matrix/impl/index.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/index.clj
@@ -1,11 +1,12 @@
 (ns clojure.core.matrix.impl.index
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.protocols :as mp]))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.utils :refer :all])
+  (:import [clojure.lang IPersistentVector]))
 
 (extend-protocol mp/PIndexImplementation
   (Class/forName "[J")
 	  (index? [m]
-      true) 
+      true)
 	  (index-to-longs [m]
       m)
 	  (index-to-ints [m]
@@ -20,7 +21,7 @@
 (extend-protocol mp/PIndexImplementation
   (Class/forName "[I")
 	  (index? [m]
-      true) 
+      true)
 	  (index-to-longs [m]
       (long-array m))
 	  (index-to-ints [m]
@@ -33,9 +34,9 @@
       (mp/index-to-ints a)))
 
 (extend-protocol mp/PIndexImplementation
-  clojure.lang.IPersistentVector
+  IPersistentVector
 	  (index? [m]
-      (every? integer? m)) 
+      (every? integer? m))
 	  (index-to-longs [m]
       (long-array m))
 	  (index-to-ints [m]
@@ -45,11 +46,11 @@
 	  (index-from-ints [m xs]
       (vec xs))
 	  (index-coerce [m a]
-      (cond 
+      (cond
         (mp/index? a)
           (mp/persistent-vector-coerce a)
-        (== 1 (mp/dimensionality a)) 
+        (== 1 (mp/dimensionality a))
           (vec (mp/index-to-longs a))
-        :else 
+        :else
           (error "Can't make a 1D index from array of shape " (mp/get-shape a)))))
 

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
@@ -1,14 +1,14 @@
 (ns clojure.core.matrix.impl.ndarray
-  (:require [clojure.walk :as w])
-  (:use clojure.core.matrix.utils)
-  (:use clojure.core.matrix.impl.ndarray-macro)
-  (:require [clojure.core.matrix.impl.default])
-  (:require [clojure.core.matrix.impl.ndarray-magic :as magic])
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.impl.mathsops :as mops])
-  (:require [clojure.core.matrix.multimethods :as mm])
-  (:refer-clojure :exclude [vector?]))
+  (:refer-clojure :exclude [vector?])
+  (:require [clojure.walk :as w]
+            [clojure.core.matrix.impl.default]
+            [clojure.core.matrix.impl.ndarray-magic :as magic]
+            [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.impl.mathsops :as mops]
+            [clojure.core.matrix.multimethods :as mm]
+            [clojure.core.matrix.utils :refer :all]
+            [clojure.core.matrix.impl.ndarray-macro :refer :all]))
 
 ;; (error "NDArray loaded!")
 
@@ -115,7 +115,7 @@
 (defn c-strides [shape]
   (let [shape-ints (int-array shape)
         n (alength shape-ints)]
-    (if-not (> n 0)
+    (if-not (pos? n)
       (int-array [1])
       (let [strides (int-array n)]
         (aset strides (dec n) (int 1))
@@ -289,7 +289,7 @@
     "Returns a sequence of row-major slices of given NDArray. Always
      returns NDArrays, even on 1d vector (0d NDArrays in this case)"
     [^typename# m]
-    (iae-when-not (> (.ndims m) 0)
+    (iae-when-not (pos? (.ndims m))
       (str "can't get slices on [" (.ndims m) "]-dimensional object"))
     (let [^ints shape (.shape m)]
       (map (partial row-major-slice#t m) (range (aget shape 0))))))
@@ -355,7 +355,7 @@
                 pivot (aget-2d* m i-pivot j)]
             ;; when maximum element is not on diagonal, swap rows, update
             ;; permutations and permutation counter
-            (when (not (== i-pivot j))
+            (when-not (== i-pivot j)
               (c-for [k (int 0) (< k n) (inc k)]
                 (let [swap (aget-2d* m i-pivot k)]
                   (aset-2d* m i-pivot k (aget-2d* m j k))
@@ -507,8 +507,8 @@
       (iae-when-not (= 2 (.ndims m))
         "can't use get-2d on non-matrix")
       (let [idx (+ offset
-                   (+ (* (aget strides 0) (int x))
-                      (* (aget strides 1) (int y))))]
+                   (* (aget strides 0) (int x))
+                   (* (aget strides 1) (int y)))]
         (aget data idx)))
     (get-nd [m indexes]
       (iae-when-not (= (count indexes) ndims)

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray_double.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray_double.clj
@@ -1,15 +1,14 @@
 (ns clojure.core.matrix.impl.ndarray-double
-  (:require [clojure.walk :as w])
-  (:use clojure.core.matrix.utils)
-  (:use clojure.core.matrix.impl.ndarray-macro)
-  (:require [clojure.core.matrix.impl.default])
-  (:require [clojure.core.matrix.impl.ndarray-magic :as magic])
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.impl.mathsops :as mops])
-  (:require [clojure.core.matrix.multimethods :as mm])
   (:refer-clojure :exclude [vector?])
-
-  (:use clojure.core.matrix.impl.ndarray))
+  (:require [clojure.core.matrix.impl.default]
+            [clojure.core.matrix.impl.ndarray-magic :as magic]
+            [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.impl.mathsops :as mops]
+            [clojure.core.matrix.multimethods :as mm]
+            [clojure.walk :as w]
+            [clojure.core.matrix.impl.ndarray :refer :all]
+            [clojure.core.matrix.utils :refer :all]
+            [clojure.core.matrix.impl.ndarray-macro :refer :all]))
 
 (magic/spit-code :double)

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray_macro.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray_macro.clj
@@ -1,12 +1,12 @@
 (ns clojure.core.matrix.impl.ndarray-macro
-  (:require [clojure.pprint])
-  (:require [clojure.walk :as w])
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.impl.ndarray-magic :as magic])
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.multimethods :as mm])
-  (:refer-clojure :exclude [vector?]))
+  (:refer-clojure :exclude [vector?])
+  (:require [clojure.pprint]
+            [clojure.walk :as w]
+            [clojure.core.matrix.impl.ndarray-magic :as magic]
+            [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.multimethods :as mm]
+            [clojure.core.matrix.utils :refer :all]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* true)

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray_magic.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray_magic.clj
@@ -1,10 +1,8 @@
 (ns clojure.core.matrix.impl.ndarray-magic
-  (:require [clojure.walk :as w])
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.multimethods :as mm])
-  (:refer-clojure :exclude [vector?]))
+  (:refer-clojure :exclude [vector?])
+  (:require [clojure.walk :as w]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.utils :refer :all]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray_object.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray_object.clj
@@ -1,15 +1,14 @@
 (ns clojure.core.matrix.impl.ndarray-object
-  (:require [clojure.walk :as w])
-  (:use clojure.core.matrix.utils)
-  (:use clojure.core.matrix.impl.ndarray-macro)
-  (:require [clojure.core.matrix.impl.default])
-  (:require [clojure.core.matrix.impl.ndarray-magic :as magic])
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.impl.mathsops :as mops])
-  (:require [clojure.core.matrix.multimethods :as mm])
   (:refer-clojure :exclude [vector?])
-
-  (:use clojure.core.matrix.impl.ndarray))
+  (:require [clojure.walk :as w]
+            [clojure.core.matrix.impl.default]
+            [clojure.core.matrix.impl.ndarray-magic :as magic]
+            [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.impl.mathsops :as mops]
+            [clojure.core.matrix.multimethods :as mm]
+            [clojure.core.matrix.utils :refer :all]
+            [clojure.core.matrix.impl.ndarray-macro :refer :all]
+            [clojure.core.matrix.impl.ndarray :refer :all]))
 
 (magic/spit-code :object)

--- a/src/main/clojure/clojure/core/matrix/impl/object_array.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/object_array.clj
@@ -1,10 +1,11 @@
 (ns clojure.core.matrix.impl.object-array
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:use clojure.core.matrix.utils)
-  (:require clojure.core.matrix.impl.persistent-vector)
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.impl.mathsops :as mops])
-  (:require [clojure.core.matrix.multimethods :as mm])
+  (:require [clojure.core.matrix.protocols :as mp]
+            clojure.core.matrix.impl.persistent-vector
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.impl.mathsops :as mops]
+            [clojure.core.matrix.multimethods :as mm]
+            [clojure.core.matrix.impl.wrappers :as wrap]
+            [clojure.core.matrix.utils :refer :all])
   (:import [java.util Arrays]))
 
 (set! *warn-on-reflection* true)
@@ -34,10 +35,10 @@
         (object-array (map construct-object-array (mp/get-major-slice-seq data))))))
 
 (defn construct-nd ^objects [shape]
-  (let [dims (long (count shape))] 
-        (cond 
+  (let [dims (long (count shape))]
+        (cond
           (== 1 dims) (object-array (long (first shape)))
-          (> dims 1)  
+          (> dims 1)
             (let [n (long (first shape))
                   m (object-array n)
                   ns (next shape)]
@@ -46,10 +47,10 @@
               m)
           :else (error "Can't make a nested object array of dimensionality: " dims))))
 
-(defn object-array-coerce 
+(defn object-array-coerce
   "Coerce to object array format, avoids copying sub-arrays if possible."
   ([m]
-  (if (> (mp/dimensionality m) 0) 
+  (if (> (mp/dimensionality m) 0)
     (if (is-object-array? m)
       (let [^objects m m
             n (count m)]
@@ -79,7 +80,7 @@
     (meta-info [m]
       {:doc "Clojure.core.matrix implementation for Java Object arrays"})
     (new-vector [m length] (construct-object-vector (long length)))
-    (new-matrix [m rows columns] 
+    (new-matrix [m rows columns]
       (let [columns (long columns)
             m (object-array rows)]
         (dotimes [i rows]
@@ -95,24 +96,24 @@
 
 (extend-protocol mp/PDimensionInfo
   (Class/forName "[Ljava.lang.Object;")
-    (dimensionality [m] 
-      (let [^objects m m] 
-        (+ 1 (mp/dimensionality (aget m 0)))))
-    (is-vector? [m] 
+    (dimensionality [m]
       (let [^objects m m]
-        (or 
+        (+ 1 (mp/dimensionality (aget m 0)))))
+    (is-vector? [m]
+      (let [^objects m m]
+        (or
          (== 0 (alength m))
          (== 0 (mp/dimensionality (aget m 0))))))
     (is-scalar? [m] false)
-    (get-shape [m] 
+    (get-shape [m]
       (let [^objects m m]
         (if (== 0 (alength m))
            1
            (cons (alength m) (mp/get-shape (aget m 0))))))
     (dimension-count [m x]
       (let [^objects m m
-            x (long x)] 
-        (cond 
+            x (long x)]
+        (cond
           (== x 0)
             (alength m)
           (> x 0)
@@ -142,8 +143,8 @@
         (cond
           (== 1 dims)
             (aget m (int (first indexes)))
-          (> dims 1) 
-            (mp/get-nd (aget m (int (first indexes))) (next indexes)) 
+          (> dims 1)
+            (mp/get-nd (aget m (int (first indexes))) (next indexes))
           (== 0 dims) m
           :else
             (error "Invalid dimensionality access with index: " (vec indexes))))))
@@ -161,7 +162,7 @@
         arr))
     (set-nd [m indexes v]
       (let [dims (long (count indexes))]
-        (cond 
+        (cond
           (== 1 dims)
             (let [^objects arr (copy-object-array m)
                   x (int (first indexes))]
@@ -171,8 +172,8 @@
             (let [^objects arr (copy-object-array m)
                   x (int (first indexes))]
               (aset arr x (mp/set-nd (aget ^objects m x) (next indexes) v))
-              arr)  
-          :else 
+              arr)
+          :else
             (error "Can't set on object array with dimensionality: " (count indexes)))))
     (is-mutable? [m] true))
 
@@ -185,7 +186,7 @@
     (set-nd! [m indexes v]
       (let [^objects m m
             dims (long (count indexes))]
-        (cond 
+        (cond
           (== 1 dims)
             (aset m (int (first indexes)) v)
           (> dims 1)
@@ -200,7 +201,7 @@
             dims (long (count mshape))
             tdims (long (count target-shape))]
         (cond
-          (> dims tdims) 
+          (> dims tdims)
             (error "Can't broadcast to a lower dimensional shape")
           (not (every? identity (map #(== %1 %2) mshape (take-last dims target-shape))))
             (error "Incompatible shapes, cannot broadcast " (vec mshape) " to " (vec target-shape))
@@ -244,26 +245,26 @@
 
 (extend-protocol mp/PSliceView
   (Class/forName "[Ljava.lang.Object;")
-    (get-major-slice-view [m i] 
+    (get-major-slice-view [m i]
       (let [^objects m m
             v (aget m i)]
         (if (mp/is-scalar? v)
-          (clojure.core.matrix.impl.wrappers/wrap-slice m i)
+          (wrap/wrap-slice m i)
           v))))
 
 (extend-protocol mp/PSliceSeq
   (Class/forName "[Ljava.lang.Object;")
     (get-major-slice-seq [m]
       (let [^objects m m]
-        (if (and (> 0 (alength m)) (== 0 (mp/dimensionality (aget m 0)))) 
+        (if (and (> 0 (alength m)) (== 0 (mp/dimensionality (aget m 0))))
           (seq (map mp/get-0d m))
           (seq m)))))
 
 (extend-protocol mp/PElementCount
   (Class/forName "[Ljava.lang.Object;")
-    (element-count [m] 
+    (element-count [m]
       (let [^objects m m
-            n (alength m)] 
+            n (alength m)]
         (if (== n 0)
           0
           (* n (mp/element-count (aget m 0)))))))
@@ -275,14 +276,14 @@
             shapes (map mp/validate-shape (seq m))]
         (if (mp/same-shapes? shapes)
           (cons (alength m) (first shapes))
-          (error "Inconsistent shapes for sub arrays in object array"))))) 
+          (error "Inconsistent shapes for sub arrays in object array")))))
 
 (extend-protocol mp/PFunctionalOperations
   (Class/forName "[Ljava.lang.Object;")
     (element-seq [m]
       (let [^objects m m]
         (cond
-          (== 0 (alength m)) 
+          (== 0 (alength m))
             '()
           (> (mp/dimensionality (aget m 0)) 0)
             (mapcat mp/element-seq m)
@@ -297,11 +298,11 @@
         (object-array (apply map #(apply mp/element-map %1 f %2 %&) m (mp/get-major-slice-seq a) (map mp/get-major-slice-seq more)))))
     (element-map!
       ([m f]
-        (dotimes [i (count m)] 
+        (dotimes [i (count m)]
           (let [^objects m m
                 s (aget m i)]
-            (if (mp/is-mutable? s) 
-              (mp/element-map! s f) 
+            (if (mp/is-mutable? s)
+              (mp/element-map! s f)
               (aset m i (mp/element-map s f)))))
         m)
       ([m f a]
@@ -309,7 +310,7 @@
           (let [^objects m m
                 s (aget m i)
                 as (mp/get-major-slice a i)]
-            (if (mp/is-mutable? s) 
+            (if (mp/is-mutable? s)
               (mp/element-map! s f as)
               (aset m i (mp/element-map s f as)))))
         m)
@@ -319,7 +320,7 @@
                 s (aget m i)
                 as (mp/get-major-slice a i)
                 ms (map #(mp/get-major-slice % i) more)]
-            (if (mp/is-mutable? s) 
+            (if (mp/is-mutable? s)
               (apply mp/element-map! s f as ms)
               (aset m i (apply mp/element-map s f as ms)))))
         m))

--- a/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
@@ -1,11 +1,11 @@
 (ns clojure.core.matrix.impl.persistent-vector
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.impl.wrappers :as wrap])
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.impl.mathsops :as mops])
-  (:require [clojure.core.matrix.multimethods :as mm])
-  (:import clojure.lang.IPersistentVector))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.impl.mathsops :as mops]
+            [clojure.core.matrix.multimethods :as mm]
+            [clojure.core.matrix.utils :refer [scalar-coerce error doseq-indexed]])
+  (:import [clojure.lang IPersistentVector Indexed]
+           [java.util List]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* true)
@@ -32,7 +32,7 @@
     (mapv persistent-vector-coerce v)))
 
 (defmacro vector-1d? [pv]
-  `(let [^clojure.lang.IPersistentVector pv# ~pv]
+  `(let [pv# ^IPersistentVector ~pv]
      (or (== 0 (.length pv#)) (== 0 (mp/dimensionality (.nth pv# 0))))))
 
 (defn- mapmatrix
@@ -56,8 +56,8 @@
             (let [v (scalar-coerce m2)] (mapv #(f % v) m1 ))
             (mapv f m1 (mp/element-seq m2))))
         :else
-          (mapv (partial mapmatrix f) 
-                m1 
+          (mapv (partial mapmatrix f)
+                m1
                 (mp/get-major-slice-seq m2)))))
   ([f m1 m2 & more]
     (if (mp/is-vector? m1)
@@ -67,7 +67,7 @@
 (defn- mapv-identity-check
   "Maps a function over a persistent vector, only modifying the vector if the function
    returns a different value"
-  ([f ^clojure.lang.IPersistentVector v]
+  ([f ^IPersistentVector v]
     (let [n (.count v)]
       (loop [i 0 v v]
         (if (< i n)
@@ -85,14 +85,14 @@
         (every? #(check-vector-shape % ns) v)
         (every? #(not (instance? IPersistentVector %)) v)))))
 
-(defn is-nested-persistent-vectors? 
+(defn is-nested-persistent-vectors?
   "Test if array is already in nested persistent vector array format."
   ([x]
     (cond
       (number? x) true
       (mp/is-scalar? x) true
-      (not (instance? clojure.lang.IPersistentVector x)) false
-      :else (and 
+      (not (instance? IPersistentVector x)) false
+      :else (and
               (every? is-nested-persistent-vectors? x)
               (check-vector-shape x (mp/get-shape x))))))
 
@@ -102,14 +102,14 @@
     (cond
       (> dims 0) (mp/convert-to-nested-vectors x) ;; any array with 1 or more dimensions
       (and (== dims 0) (not (mp/is-scalar? x))) (mp/get-0d x) ;; array with zero dimensionality
-      
+
       ;; it's not an array - so try alternative coercions
       (nil? x) x
       (.isArray (class x)) (map persistent-vector-coerce (seq x))
-      (instance? java.util.List x) (coerce-nested x)
-      (instance? java.lang.Iterable x) (coerce-nested x)
+      (instance? List x) (coerce-nested x)
+      (instance? Iterable x) (coerce-nested x)
       (sequential? x) (coerce-nested x)
-      
+
       ;; treat as a scalar value
       :default x)))
 
@@ -150,7 +150,7 @@
             dims (long (count mshape))
             tdims (long (count target-shape))]
         (cond
-          (> dims tdims) 
+          (> dims tdims)
             (error "Can't broadcast to a lower dimensional shape")
           (not (every? identity (map #(== %1 %2) mshape (take-last dims target-shape))))
             (error "Incompatible shapes, cannot broadcast " (vec mshape) " to " (vec target-shape))
@@ -226,7 +226,7 @@
 (extend-protocol mp/PSliceSeq
   IPersistentVector
     (get-major-slice-seq [m]
-      (if (vector-1d? m) 
+      (if (vector-1d? m)
         (seq (map mp/get-0d m))
         (seq m))))
 
@@ -272,7 +272,7 @@
     (validate-shape [m]
       (if (mp/same-shapes? m)
         (mp/get-shape m)
-        (error "Inconsistent shape for persistent vector array.")))) 
+        (error "Inconsistent shape for persistent vector array."))))
 
 (extend-protocol mp/PMatrixAdd
   IPersistentVector
@@ -290,8 +290,8 @@
             ;; b (persistent-vector-coerce b)
             ]
         (cond
-          (and (== dims 1) (instance? clojure.lang.Indexed b))
-            (do 
+          (and (== dims 1) (instance? Indexed b))
+            (do
               (when-not (== (count a) (count b)) (error "Mismatched vector sizes"))
               (reduce + 0 (map * a b)))
           (== dims 0) (mp/scale a b)
@@ -333,16 +333,16 @@
     (matrix-equals [a b]
       (let [bdims (long (mp/dimensionality b))]
         (cond
-          (<= bdims 0) 
+          (<= bdims 0)
             false
-          (not= (count a) (mp/dimension-count b 0)) 
+          (not= (count a) (mp/dimension-count b 0))
             false
           (== 1 bdims)
             (and (== 1 (mp/dimensionality a))
                  (let [n (long (count a))]
                    (loop [i 0]
                      (if (< i n)
-                       (if (== (mp/get-1d a i) (mp/get-1d b i)) 
+                       (if (== (mp/get-1d a i) (mp/get-1d b i))
                          (recur (inc i))
                          false)
                        true))))
@@ -350,11 +350,11 @@
             (let [n (long (count a))]
                (loop [i 0]
                      (if (< i n)
-                       (if (mp/matrix-equals (a i) (b i)) 
+                       (if (mp/matrix-equals (a i) (b i))
                          (recur (inc i))
                          false)
                        true)))
-          :else 
+          :else
             (loop [sa (seq a) sb (mp/get-major-slice-seq b)]
               (if sa
                 (if (mp/matrix-equals (first sa) (first sb))
@@ -405,7 +405,7 @@
 
 (extend-protocol mp/PSquare
   IPersistentVector
-    (square [m] 
+    (square [m]
       (mapmatrix #(* % %) m)))
 
 (extend-protocol mp/PRowOperations
@@ -429,7 +429,7 @@
 ;; we generate both name and name! versions
 (eval
   `(extend-protocol mp/PMathsFunctions
-     clojure.lang.IPersistentVector
+     IPersistentVector
        ~@(map build-maths-function mops/maths-ops)
        ~@(map (fn [[name func]]
                 (let [name (str name "!")
@@ -463,9 +463,9 @@
 
 (extend-protocol mp/PElementCount
   IPersistentVector
-    (element-count [m] 
-      (let [c (long (count m))] 
-        (if (== c 0) 
+    (element-count [m]
+      (let [c (long (count m))]
+        (if (== c 0)
           0
           (* c (mp/element-count (m 0)))))))
 
@@ -487,7 +487,7 @@
       (not (vector? m))
         (doseq-indexed [v (mp/element-seq m) i]
           (aset arr (+ off i) (double v)))
-      (and (== size ct) (not (vector? (nth m 0 nil)))) 
+      (and (== size ct) (not (vector? (nth m 0 nil))))
         (dotimes [i size]
           (aset arr (+ off i) (double (.nth ^IPersistentVector m i))))
       :else
@@ -508,11 +508,11 @@
 
 (defn- copy-to-object-array [m ^objects arr ^long off ^long size]
   (let [ct (count m)]
-    (cond 
+    (cond
       (not (vector? m))
         (doseq-indexed [v (mp/element-seq m) i]
           (aset arr (+ off i) v))
-      (and (== size ct) (not (vector? (nth m 0 nil)))) 
+      (and (== size ct) (not (vector? (nth m 0 nil))))
         (dotimes [i size]
           (aset arr (+ off i) (.nth ^IPersistentVector m i)))
       :else
@@ -535,7 +535,7 @@
   IPersistentVector
     (element-seq [m]
       (cond
-        (== 0 (count m)) 
+        (== 0 (count m))
           '()
         (> (mp/dimensionality (m 0)) 0)
           (mapcat mp/element-seq m)
@@ -550,7 +550,7 @@
         (apply mapmatrix f m a more)))
     (element-map!
       ([m f]
-        (doseq [s m] 
+        (doseq [s m]
           (mp/element-map! s f))
         m)
       ([m f a]

--- a/src/main/clojure/clojure/core/matrix/impl/pprint.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/pprint.clj
@@ -1,8 +1,7 @@
 (ns clojure.core.matrix.impl.pprint
   (:require [clojure.core.matrix.protocols :as mp])
-  (:use clojure.core.matrix.utils)
-  (:import [java.lang StringBuilder])
-  (:import [clojure.lang IPersistentVector]))
+  (:import [java.lang StringBuilder]
+           [clojure.lang IPersistentVector]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* true)
@@ -22,20 +21,20 @@
   "Finds the longest string length of each column in an array of Strings."
   [m]
   (let [ss (mp/get-slice-seq m (dec (mp/dimensionality m)))]
-    (mapv 
-      (fn [s] (mp/element-reduce s 
-                                 (fn [acc ^String e] (max acc (.length e))) 
+    (mapv
+      (fn [s] (mp/element-reduce s
+                                 (fn [acc ^String e] (max acc (.length e)))
                                  0))
       ss)))
 
-(defn- format-array 
+(defn- format-array
   "Formats an array according to the given formatter function"
   ([m formatter]
     (let [m (mp/ensure-type m String)]
-      (cond 
+      (cond
         (mp/is-scalar? m) (formatter m)
-        :else (mp/element-map 
-                (if (= java.lang.Object (mp/element-type m))
+        :else (mp/element-map
+                (if (= Object (mp/element-type m))
                   m
                   (mp/convert-to-nested-vectors m))
                 formatter)))))
@@ -81,7 +80,7 @@
 
 (defn pm
   "Pretty-prints an array. Returns a String containing the pretty-printed representation."
-  ([a] 
+  ([a]
     (pm a nil))
   ([a {:keys [prefix formatter]}]
     (let [formatter (or formatter default-formatter)
@@ -90,8 +89,8 @@
           sb (StringBuilder.)]
       (cond
         (mp/is-scalar? m) (.append sb (str prefix m))
-        (== 1 (mp/dimensionality m)) 
+        (== 1 (mp/dimensionality m))
           (append-row sb m (column-lengths m))
-        :else 
+        :else
           (let [clens (column-lengths m)] (rprint sb m prefix clens)))
       (.toString sb))))

--- a/src/main/clojure/clojure/core/matrix/impl/sequence.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/sequence.clj
@@ -1,10 +1,8 @@
 (ns clojure.core.matrix.impl.sequence
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.impl.mathsops :as mops])
-  (:require [clojure.core.matrix.impl.wrappers :as wrap])
-  (:require [clojure.core.matrix.multimethods :as mm]))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.utils :refer [scalar-coerce error]])
+  (:import [clojure.lang ISeq]))
 
 ;; core.matrix implementation for Clojure ISeq objects
 ;;
@@ -16,13 +14,13 @@
 (set! *unchecked-math* true)
 
 (extend-protocol mp/PImplementation
-  clojure.lang.ISeq
+  ISeq
     (implementation-key [m] :sequence)
     (meta-info [m]
       {:doc "Core.matrix implementation for Clojure ISeq objects"})
-    (new-vector [m length] 
+    (new-vector [m length]
       (mp/new-vector [] length))
-    (new-matrix [m rows columns] 
+    (new-matrix [m rows columns]
       (mp/new-matrix [] rows columns))
     (new-matrix-nd [m dims]
       (mp/new-matrix-nd [] dims))
@@ -32,7 +30,7 @@
       true))
 
 (extend-protocol mp/PIndexedAccess
-  clojure.lang.ISeq
+  ISeq
     (get-1d [m x]
       (scalar-coerce (nth m x)))
     (get-2d [m x y]
@@ -48,7 +46,7 @@
         )))
 
 (extend-protocol mp/PIndexedSetting
-  clojure.lang.ISeq
+  ISeq
     (set-1d [m row v]
       (mp/set-1d (mp/convert-to-nested-vectors m) row v))
     (set-2d [m row column v]
@@ -59,33 +57,33 @@
       false))
 
 (extend-protocol mp/PBroadcast
-  clojure.lang.ISeq
+  ISeq
     (broadcast [m new-shape]
       (mp/broadcast (mp/convert-to-nested-vectors m) new-shape)))
 
 (extend-protocol mp/PBroadcastLike
-  clojure.lang.ISeq
+  ISeq
     (broadcast-like [m a]
       (mp/broadcast (mp/convert-to-nested-vectors a) (mp/get-shape m))))
 
 (extend-protocol mp/PSliceView
-  clojure.lang.ISeq
+  ISeq
     (get-major-slice-view [m i]
       (nth m i)))
 
 (extend-protocol mp/PSliceSeq
-  clojure.lang.ISeq
+  ISeq
     (get-major-slice-seq [m] m))
 
 (extend-protocol mp/PConversion
-  clojure.lang.ISeq
+  ISeq
     (convert-to-nested-vectors [m]
-      (if (> (mp/dimensionality (first m)) 0) 
+      (if (> (mp/dimensionality (first m)) 0)
         (mapv mp/convert-to-nested-vectors m)
         (mapv mp/get-0d m))))
 
 (extend-protocol mp/PDimensionInfo
-  clojure.lang.ISeq
+  ISeq
     (dimensionality [m]
       (inc (mp/dimensionality (first m))))
     (is-vector? [m]
@@ -100,7 +98,7 @@
         (mp/dimension-count (first m) (dec x)))))
 
 (extend-protocol mp/PFunctionalOperations
-  clojure.lang.ISeq
+  ISeq
     (element-seq [m]
       (mapcat mp/element-seq m))
     (element-map

--- a/src/main/clojure/clojure/core/matrix/impl/sparse_map.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/sparse_map.clj
@@ -1,7 +1,8 @@
 (ns clojure.core.matrix.impl.sparse-map
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.implementations :as imp]))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.utils :refer :all])
+  (:import [clojure.lang IPersistentMap]))
 
 ;; =============================================================
 ;; core.matrix implementation enabling a map with appropriate
@@ -22,14 +23,14 @@
     (vary-meta m assoc :shape (to-long-array shape))))
 
 (extend-protocol mp/PImplementation
-  clojure.lang.IPersistentMap
+  IPersistentMap
     (implementation-key [m] :persistent-map)
     (meta-info [m]
       {:doc "Core.matrix implementation enabling a map with appropriate
              metadata to be used as a core.matrix implementation."})
-    (new-vector [m length] 
+    (new-vector [m length]
       (vary-meta (with-shape {} [length]) assoc :default-value 0.0))
-    (new-matrix [m rows columns] 
+    (new-matrix [m rows columns]
       (vary-meta (with-shape {} [rows columns]) assoc :default-value 0.0))
     (new-matrix-nd [m dims]
       (with-shape {} dims))
@@ -45,7 +46,7 @@
       true))
 
 (extend-protocol mp/PDimensionInfo
-  clojure.lang.IPersistentMap
+  IPersistentMap
     (dimensionality [m]
       (if-let [sh (:shape (meta m))]
         (count sh)
@@ -62,7 +63,7 @@
       (nth (:shape (meta m)) x)))
 
 (extend-protocol mp/PIndexedAccess
-  clojure.lang.IPersistentMap
+  IPersistentMap
     (get-1d [m x]
       (or (m [x]) (:default-value (meta m))))
     (get-2d [m x y]
@@ -71,7 +72,7 @@
       (or (m (vec indexes)) (:default-value (meta m)))))
 
 (extend-protocol mp/PIndexedSetting
-  clojure.lang.IPersistentMap
+  IPersistentMap
     (set-1d [m row v]
       (assoc m [row] v))
     (set-2d [m row column v]

--- a/src/main/clojure/clojure/core/matrix/impl/wrappers.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/wrappers.clj
@@ -1,8 +1,8 @@
 (ns clojure.core.matrix.impl.wrappers
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.multimethods :as mm]))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix.utils :as u :refer [TODO error]])
+  (:import [clojure.lang Seqable Indexed]))
 
 ;; =============================================
 ;; WRAPPER IMPLEMENTATIONS
@@ -21,7 +21,7 @@
 ;; wraps a single scalar as a mutable 0-D array
 
 (deftype ScalarWrapper [^{:volatile-mutable true} value]
-  java.lang.Object
+  Object
     (toString [m] (str value))
 
   mp/PImplementation
@@ -98,7 +98,7 @@
 ;; wraps a row-major slice of an array
 
 (deftype SliceWrapper [array ^long slice]
-  clojure.lang.Seqable
+  Seqable
     (seq [m]
       (mp/get-major-slice-seq m))
 
@@ -180,7 +180,7 @@
   mp/PMatrixCloning
     (clone [m] (wrap-slice (mp/clone array) slice))
 
-  java.lang.Object
+  Object
     (toString [m] (str (mp/convert-to-nested-vectors m))))
 
 
@@ -205,12 +205,12 @@
    ^objects index-maps ;; maps of each NDWrapper dimension's indexes to source dimension indexes
    ^longs source-position ;; position in source array for non-specified dimensions
    ]
-  clojure.lang.Seqable
+  Seqable
     (seq [m]
       (mp/get-major-slice-seq m))
-    
-  clojure.lang.Indexed
-    (count [m] 
+
+  Indexed
+    (count [m]
       (aget shape 0))
     (nth [m i]
       (mp/get-major-slice m i))
@@ -260,9 +260,9 @@
           (aset new-index-map i (aget old-index-map (+ start i))))
         (NDWrapper.
           array
-          (long-array-of length)
+          (u/long-array-of length)
           dim-map
-          (object-array-of new-index-map)
+          (u/object-array-of new-index-map)
           source-position)))
 
   mp/PDimensionInfo
@@ -285,38 +285,38 @@
 
   mp/PIndexedAccess
     (get-1d [m row]
-      (let [ix (copy-long-array source-position)
+      (let [ix (u/copy-long-array source-position)
             ^longs im (aget index-maps 0)]
         (set-source-index ix 0 row)
         (mp/get-nd array ix)))
     (get-2d [m row column]
-      (let [ix (copy-long-array source-position)]
+      (let [ix (u/copy-long-array source-position)]
         (set-source-index ix 0 row)
         (set-source-index ix 1 column)
         (mp/get-nd array ix)))
     (get-nd [m indexes]
-      (let [^longs ix (copy-long-array source-position)]
+      (let [^longs ix (u/copy-long-array source-position)]
         (dotimes [i (alength shape)]
           (set-source-index ix i (nth indexes i)))
         (mp/get-nd array ix)))
     mp/PIndexedSettingMutable
     (set-1d! [m row v]
-      (let [ix (copy-long-array source-position)
+      (let [ix (u/copy-long-array source-position)
             ^longs im (aget index-maps 0)]
         (set-source-index ix 0 row)
         (mp/set-nd! array ix v)))
     (set-2d! [m row column v]
-      (let [ix (copy-long-array source-position)]
+      (let [ix (u/copy-long-array source-position)]
         (set-source-index ix 0 row)
         (set-source-index ix 1 column)
         (mp/set-nd! array ix v)))
     (set-nd! [m indexes v]
-      (let [^longs ix (copy-long-array source-position)]
+      (let [^longs ix (u/copy-long-array source-position)]
         (dotimes [i (alength shape)]
           (set-source-index ix i (nth indexes i)))
         (mp/set-nd! array ix v)))
 
-  java.lang.Object
+  Object
     (toString [m]
       (str (mp/persistent-vector-coerce m))))
 
@@ -334,8 +334,8 @@
             dims (alength shp)]
         (NDWrapper. m
                   shp
-                  (long-range dims)
-                  (object-array (map #(long-range (mp/dimension-count m %)) (range dims)))
+                  (u/long-range dims)
+                  (object-array (map #(u/long-range (mp/dimension-count m %)) (range dims)))
                   (long-array (repeat dims 0))))))
 (defn wrap-selection
   [m indices]

--- a/src/main/clojure/clojure/core/matrix/implementations.clj
+++ b/src/main/clojure/clojure/core/matrix/implementations.clj
@@ -1,6 +1,6 @@
 (ns clojure.core.matrix.implementations
-  (:use [clojure.core.matrix.utils])
-  (:require [clojure.core.matrix.protocols :as mp]))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.utils :refer [error]]))
 
 ;; =====================================================
 ;; Implementation utilities

--- a/src/main/clojure/clojure/core/matrix/linear.clj
+++ b/src/main/clojure/clojure/core/matrix/linear.clj
@@ -1,11 +1,10 @@
 (ns clojure.core.matrix.linear
-  (:use clojure.core.matrix)
-  (:require [clojure.core.matrix.impl default])
-  (:require [clojure.core.matrix.protocols :as mp]))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix :refer :all]))
 
 
 (defn norm
-  "Computes the norm of a matrix or vector. 
+  "Computes the norm of a matrix or vector.
 
    By default calculates 2-norm for vectors and Frobenius 2-norm for matrices. The optinal p argument specifies use of the p-norm instead.
 

--- a/src/main/clojure/clojure/core/matrix/operators.clj
+++ b/src/main/clojure/clojure/core/matrix/operators.clj
@@ -1,7 +1,7 @@
 (ns clojure.core.matrix.operators
-  (:use clojure.core.matrix.utils) 
   (:refer-clojure :exclude [* - + / vector? ==])
-  (:require [clojure.core.matrix :as m]))
+  (:require [clojure.core.matrix :as m]
+            [clojure.core.matrix.utils :refer [error]]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* true)
@@ -59,18 +59,18 @@
 (defmacro Σ
   "Computes array summation over a range of values for one or more variables"
   ([[sym vals & more :as bindings] exp]
-    (cond 
+    (cond
       (odd? (count bindings)) (error "Summation requires an even number of forms in binding vector")
       (seq more) `(Σ [~sym ~vals] (Σ [~@more] ~exp))
-      :else `(reduce m/add (map (fn [i#] (let [~sym i#] ~exp)) ~vals))))) 
+      :else `(reduce m/add (map (fn [i#] (let [~sym i#] ~exp)) ~vals)))))
 
 (defmacro Π
   "Computes array products over a range of values for one or more variables"
   ([[sym vals & more :as bindings] exp]
-    (cond 
+    (cond
       (odd? (count bindings)) (error "Summation requires an even number of forms in binding vector")
       (seq more) `(Σ [~sym ~vals] (Σ [~@more] ~exp))
-      :else `(reduce m/mul (map (fn [i#] (let [~sym i#] ~exp)) ~vals))))) 
+      :else `(reduce m/mul (map (fn [i#] (let [~sym i#] ~exp)) ~vals)))))
 
 ;; ===================================================
 ;; inplace operators

--- a/src/main/clojure/clojure/core/matrix/protocols.clj
+++ b/src/main/clojure/clojure/core/matrix/protocols.clj
@@ -1,6 +1,8 @@
 (ns clojure.core.matrix.protocols
-  (:require [clojure.core.matrix.utils :refer [error same-shape-object? broadcast-shape]])
-  (:require [clojure.core.matrix.impl.mathsops :as mops]))
+  (:import [java.util List]
+           [clojure.lang Seqable])
+  (:require [clojure.core.matrix.utils :refer [error same-shape-object? broadcast-shape]]
+            [clojure.core.matrix.impl.mathsops :as mops]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* true)
@@ -141,18 +143,18 @@
   (nonzero-count [m]))
 
 (defprotocol PValidateShape
-  "Optional protocol to validate the shape of a matrix. If the matrix has an incorrect shape, should 
+  "Optional protocol to validate the shape of a matrix. If the matrix has an incorrect shape, should
    throw an error. Otherwise it should return the correct shape."
-  (validate-shape [m])) 
+  (validate-shape [m]))
 
 (defprotocol PRowColMatrix
   "Protocol to support construction of row and column matrices from 1D vectors.
 
-   A vector of length N should be converted to a 1xN or Nx1 matrix respectively.   
+   A vector of length N should be converted to a 1xN or Nx1 matrix respectively.
 
    Should throw an error if the data is not a 1D vector"
   (column-matrix [m data])
-  (row-matrix [m data])) 
+  (row-matrix [m data]))
 
 (defprotocol PMutableMatrixConstruction
   "Protocol for creating a mutable copy of a matrix. If implemented, must return either a fully mutable
@@ -260,7 +262,7 @@
 
 (defprotocol PConversion
   "Protocol to allow conversion to Clojure-friendly vector format. Optional for implementers,
-   however providing an efficient implementation is strongly encouraged to enable fast interop 
+   however providing an efficient implementation is strongly encouraged to enable fast interop
    with Clojure vectors."
   (convert-to-nested-vectors [m] "Converts an array to nested Clojure persistent vectors"))
 
@@ -273,7 +275,7 @@
   (reshape [m shape]))
 
 (defprotocol PPack
-  "Protocol to efficiently pack an array, according to the most efficient representation for a given 
+  "Protocol to efficiently pack an array, according to the most efficient representation for a given
    implementation.
 
    Definition of pack is up to the implementation to interpret, but the general rules are:
@@ -281,10 +283,10 @@
    2. Must not change the shape of the array
    3. May preserve sparse representation
    4. Should convert to most efficient format for common operations (e.g. mget, inner-product)"
-  (pack [m])) 
+  (pack [m]))
 
 (defprotocol PSameShape
-  "Protocol to test if two arrays have the same shape. Implementations may have an optimised 
+  "Protocol to test if two arrays have the same shape. Implementations may have an optimised
    method for shape equality tests, and this is a frequently required operations so it may
    make sense to provide an optimised implementation."
   (same-shape? [a b]))
@@ -315,7 +317,7 @@
   (get-major-slice-view [m i] "Gets a view of a major array slice"))
 
 (defprotocol PSliceSeq
-  "Returns the row-major slices of the array as a sequence. 
+  "Returns the row-major slices of the array as a sequence.
 
    These must be views or immutable sub-arrays for higher order slices, or scalars
    for the slices of a 1D vector.
@@ -324,14 +326,14 @@
   (get-major-slice-seq [m] "Gets a sequence of all major array slices"))
 
 (defprotocol PSliceSeq2
-  "Returns slices of the array as a sequence. 
+  "Returns slices of the array as a sequence.
 
    These must be views or immutable sub-arrays for higher order slices, or scalars
    for the slices of a 1D vector."
   (get-slice-seq [m dim] "Gets a sequence of all array slices"))
 
 (defprotocol PSliceViewSeq
-  "Returns the row-major slice views of the array. 
+  "Returns the row-major slice views of the array.
 
    These must be arrays if the array is mutable, i.e. slices of a 1D vector
    must be 0-dimensional mutable arrays."
@@ -514,7 +516,7 @@
   (pre-scale! [m factor]))
 
 (defprotocol PMatrixAdd
-  "Protocol to support addition and subtraction on arbitrary matrices. 
+  "Protocol to support addition and subtraction on arbitrary matrices.
    These are elementwise operations that should support broadcasting."
   (matrix-add [m a])
   (matrix-sub [m a]))
@@ -549,15 +551,15 @@
   "Rotates an array along a specified dimension by the given number of places.
 
    Rotating a dimension that does not exist has no effect on the array."
-  (rotate [m dim places])) 
+  (rotate [m dim places]))
 
 (defprotocol PRotateAll
   "Rotates an array using the specified shifts for each dimension.
 
    shifts may be any sequence of iteger shift amounts."
-  (rotate-all [m shifts])) 
+  (rotate-all [m shifts]))
 
-(defprotocol PTransposeInPlace 
+(defprotocol PTransposeInPlace
   "Protocol for mutable 2D matrix transpose in place"
   (transpose! [m]
     "Transposes a mutable 2D matrix in place"))
@@ -577,13 +579,13 @@
 (defprotocol PVectorOps
   "Protocol to support common numerical vector operations."
   (vector-dot [a b]
-     "Numerical dot product of two vectors. Must return a scalar value if the two parameters are 
+     "Numerical dot product of two vectors. Must return a scalar value if the two parameters are
       vectors of equal length.
 
       If the vectors are of unequal length, should throw an exception (however returning nil is
       also acceptable).
 
-      Otherwise the implementation may optionally either return nil or compute a higher dimensional 
+      Otherwise the implementation may optionally either return nil or compute a higher dimensional
       inner-product (if it is able to do so).")
   (length [a]
      "Euclidian length of a vector.")
@@ -695,7 +697,7 @@
   (element-count [m]))
 
 (defprotocol PElementMinMax
-  "Protocol to return the minimum and maximum elements in a numerical array. Must throw an exception 
+  "Protocol to return the minimum and maximum elements in a numerical array. Must throw an exception
    if the array is not numerical."
   (element-min [m])
   (element-max [m]))
@@ -711,7 +713,7 @@
     [m f]
     [m f a]
     [m f a more]
-    "Maps f over all elements of m (and optionally other matrices), returning a new matrix. 
+    "Maps f over all elements of m (and optionally other matrices), returning a new matrix.
      f is expected to produce elements of a type supported by the implementation of m - failure
      to do so may cause an error.")
   (element-map!
@@ -860,7 +862,7 @@
   "EXPERIMENTAL: Protocol for querying multi-dimensioned datasets"
   (dimension-name [ds idx dim] "Returns the name of the specified index along a given numbered dimension")
   (row-name [ds idx] "Returns the name of the row (dimension 0) at a specified index")
-  (column-name [ds idx] "returns the name of the column (dimension 1) at a specified column index")) 
+  (column-name [ds idx] "returns the name of the column (dimension 1) at a specified column index"))
 
 ;; ============================================================
 ;; Utility functions
@@ -871,10 +873,10 @@
     (cond
       (== dims 0) (get-0d x) ;; first handle scalar / 0d case
       (clojure.core/vector? x) (mapv convert-to-nested-vectors x)
-      (== dims 1) (vec (element-seq x)) 
-      (instance? java.util.List x) (mapv convert-to-nested-vectors x)
-      (instance? java.lang.Iterable x) (mapv convert-to-nested-vectors x)
-      (instance? clojure.lang.Seqable x) (mapv convert-to-nested-vectors x)
+      (== dims 1) (vec (element-seq x))
+      (instance? List x) (mapv convert-to-nested-vectors x)
+      (instance? Iterable x) (mapv convert-to-nested-vectors x)
+      (instance? Seqable x) (mapv convert-to-nested-vectors x)
       (.isArray (class x)) (mapv convert-to-nested-vectors (seq x))
       (not (is-scalar? x)) (mapv convert-to-nested-vectors (get-major-slice-seq x))
       :default (error "Can't coerce to vector: " (class x)))))
@@ -900,7 +902,7 @@
         (if (same-shape-object? s (first ns))
           (recur s (next ns))
           false)
-        true)))) 
+        true))))
 
 (defn supports-type?
   "Checks if an array can contain a specified Java type."
@@ -908,7 +910,7 @@
     (let [^Class mc (element-type m)]
       (.isAssignableFrom mc klass))))
 
-(defn ensure-type 
+(defn ensure-type
   "Checks if an array can contain a specified Java type, if so returns the orifginal array, otherwise
    returns a copy of the array that can support the sepecified type."
   [m ^Class klass]

--- a/src/main/clojure/clojure/core/matrix/select.clj
+++ b/src/main/clojure/clojure/core/matrix/select.clj
@@ -1,6 +1,6 @@
 (ns clojure.core.matrix.select
-  (:use [clojure.core.matrix])
-  (:require [clojure.core.matrix.protocols :as mp]))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix :refer :all]))
 
 ;; high-level array indexing
 ;; Provides a matlab-like dsl for matrix indexing.
@@ -110,7 +110,7 @@
 (defn end
   "selector function for sel. selects the last valid index"
   [a dim]
-  (- (dimension-count a dim) 1))
+  (dec (dimension-count a dim)))
 
 (defn calc [f & args]
   (fn [a dim]

--- a/src/main/clojure/clojure/core/matrix/utils.clj
+++ b/src/main/clojure/clojure/core/matrix/utils.clj
@@ -1,6 +1,7 @@
 (ns clojure.core.matrix.utils
   (:refer-clojure :exclude [update])
-  (:require [clojure.reflect :as r]))
+  (:require [clojure.reflect :as r])
+  (:import [java.util Arrays]))
 
 ;; Some of these are copies of methods from the library
 ;;   https://github.com/mikera/clojure-utils
@@ -13,7 +14,7 @@
 (defmacro error
   "Throws an error with the provided message(s)"
   ([& vals]
-    `(throw (java.lang.RuntimeException. (str ~@vals)))))
+    `(throw (RuntimeException. (str ~@vals)))))
 
 (defmacro error?
   "Returns true if executing body throws an error, false otherwise."
@@ -27,7 +28,7 @@
 (defmacro error
   "Throws an error with the provided message(s)"
   ([& vals]
-    `(throw (java.lang.RuntimeException. (str ~@vals)))))
+    `(throw (RuntimeException. (str ~@vals)))))
 
 ;; useful TODO macro: facilitates searching for TODO while throwing an error at runtime :-)
 (defmacro TODO
@@ -46,7 +47,7 @@
      (iae ~exception-str)))
 
 (defmacro java-array? [m]
-  `(.isArray (.getClass ~m))) 
+  `(.isArray (.getClass ~m)))
 
 (defn valid-shape?
   "returns true if the given object is a valid core.matrix array shape."
@@ -93,17 +94,17 @@
 (defn copy-double-array
   "Returns a copy of a double array"
   (^doubles [^doubles arr]
-    (java.util.Arrays/copyOf arr (int (alength arr)))))
+    (Arrays/copyOf arr (int (alength arr)))))
 
 (defn copy-long-array
   "Returns a copy of a long array"
   (^longs [^longs arr]
-    (java.util.Arrays/copyOf arr (int (alength arr)))))
+    (Arrays/copyOf arr (int (alength arr)))))
 
 (defn copy-object-array
   "Returns a copy of a long array"
   (^objects [^objects arr]
-    (java.util.Arrays/copyOf arr (int (alength arr)))))
+    (Arrays/copyOf arr (int (alength arr)))))
 
 (defn long-range
   "Returns a range of longs in a long[] array"
@@ -219,14 +220,14 @@
 
 (defmacro abutnth [i xs]
   `(let [n# (alength ~xs)
-         new-xs# (java.util.Arrays/copyOf ~xs (int (dec n#)))]
+         new-xs# (Arrays/copyOf ~xs (int (dec n#)))]
      (c-for [j# (int ~i) (< j# (dec n#)) (inc j#)]
        (aset new-xs# (int j#) (aget ~xs (int (inc j#)))))
      new-xs#))
 
 (defmacro areverse [xs]
   `(let [n# (alength ~xs)
-         new-xs# (java.util.Arrays/copyOf ~xs (int n#))]
+         new-xs# (Arrays/copyOf ~xs (int n#))]
      (c-for [i# (int 0) (< i# (quot n# 2)) (inc i#)]
        (let [j# (- (- n# 1) i#)
              t# (aget new-xs# j#)]
@@ -234,11 +235,11 @@
          (aset new-xs# i# t#)))
      new-xs#))
 
-(defmacro scalar-coerce 
+(defmacro scalar-coerce
   "Macro to coerce to scalar value with an efficient dispatch sequence"
   ([x]
   `(let [x# ~x]
-     (cond 
+     (cond
        (number? x#) x#
        :else (clojure.core.matrix.protocols/get-0d x#)))))
 
@@ -256,7 +257,7 @@
     (extends? proto cls)
     (let [bases (-> cls (r/type-reflect :ancestors true) :ancestors)]
       (->> bases
-           (filter (complement #{'java.lang.Object}))
+           (filter (complement #{'Object}))
            (map resolve)
            (cons cls)
            (map (partial extends? proto))

--- a/src/test/clojure/clojure/core/matrix/benchmark.clj
+++ b/src/test/clojure/clojure/core/matrix/benchmark.clj
@@ -1,7 +1,6 @@
 (ns clojure.core.matrix.benchmark
-  (:use clojure.core.matrix)
-  (:require [criterium.core :as c])
-  (:require [clojure.core.matrix.impl.persistent-vector]))
+  (:require [criterium.core :as c]
+            [clojure.core.matrix :refer [add esum]]))
 
 ;; miscellaneous benchmark code
 ;;
@@ -15,7 +14,7 @@
 
   (let [da (double-array [1 1])]
     (c/quick-bench (add da da)))
-  
+
   (let [da (double-array (range 100))]
     (c/quick-bench (esum da)))
 

--- a/src/test/clojure/clojure/core/matrix/demo/geom.clj
+++ b/src/test/clojure/clojure/core/matrix/demo/geom.clj
@@ -1,5 +1,5 @@
 (ns clojure.core.matrix.demo.geom
-  (:use clojure.core.matrix))
+  (:require [clojure.core.matrix :refer :all]))
 
 (def π 3.141592653589793)
 

--- a/src/test/clojure/clojure/core/matrix/demo/gravity.clj
+++ b/src/test/clojure/clojure/core/matrix/demo/gravity.clj
@@ -1,18 +1,18 @@
 (ns clojure.core.matrix.demo.gravity
-  (:use clojure.core.matrix)
+  (:require [clojure.core.matrix :refer :all])
   (:refer-clojure :exclude [update])
-  (:import [javax.swing JFrame JPanel JComponent Timer])
-  (:import [java.awt Dimension Graphics Color])
-  (:import [java.awt.event ActionListener ActionEvent]))
+  (:import [javax.swing JFrame JComponent Timer]
+           [java.awt Dimension Graphics Color]
+           [java.awt.event ActionListener ActionEvent]))
 
 ;; model is a 2D array of [colour radius position velocity mass] for each object
 (defn new-model [n]
   (vec (for [i (range n)]
                     (let [radius (rand)]
-                      [(rand-int 16777216) 
-                       radius 
-                       (vec (repeatedly 3 #(+ 0.3 (* (rand) 0.4)))) 
-                       (vec (repeatedly 3 #(* 0.2 (- (rand) 0.5)))) 
+                      [(rand-int 16777216)
+                       radius
+                       (vec (repeatedly 3 #(+ 0.3 (* (rand) 0.4))))
+                       (vec (repeatedly 3 #(* 0.2 (- (rand) 0.5))))
                        (* radius radius radius)]))))
 
 ;; a gravitational constant
@@ -26,18 +26,18 @@
         n (dimension-count model 0)
         positions (slice model 1 2)
         masses (slice model 1 4)
-        calc-force-vector (fn [pos] ;; calculate the gravity field at a point in space 
+        calc-force-vector (fn [pos] ;; calculate the gravity field at a point in space
                             (let [offsets (sub positions pos)
                                   dists (mapv length offsets)
                                   DR (* 2.0 R)]
-                              (reduce (fn [acc i] 
+                              (reduce (fn [acc i]
                                         (let [dist (double (max DR (mget dists i)))]
-                                          (add acc (mul G (mget masses i) (/ 1.0 dist dist dist) (mget offsets i))))) 
-                                      [0 0 0] 
+                                          (add acc (mul G (mget masses i) (/ 1.0 dist dist dist) (mget offsets i)))))
+                                      [0 0 0]
                                       (range n))))]
     (mapv (fn [[colour radius position velocity mass]]
             (let [new-pos (add-scaled position velocity time)
-                  force (mul mass (calc-force-vector position))  
+                  force (mul mass (calc-force-vector position))
                   new-vel (add-scaled velocity force (/ time mass))]
               [colour radius new-pos new-vel mass]))
       model)))
@@ -50,7 +50,7 @@
                                    w (int (.getWidth this))
                                    m (int (min h w))]
                                (.setColor g (Color/BLACK))
-                               (.fillRect g 0 0 w h)    
+                               (.fillRect g 0 0 w h)
                                (doseq [[colour radius pos] @model]
                                  (let [x (double (mget pos 0))
                                        y (double (mget pos 1))
@@ -63,13 +63,13 @@
                                      (* m r) (* m r)))))))
         ^JFrame frame (JFrame. "Gravity demo")
         ^ActionListener anim (proxy [ActionListener] []
-                           (actionPerformed [^ActionEvent e]                          
+                           (actionPerformed [^ActionEvent e]
                              (when (.isShowing comp)
                                (swap! model update 0.02)
                                 (.repaint comp))))]
     (.setPreferredSize comp (Dimension. 700 700))
     (.add (.getContentPane frame) comp)
-    (.start (Timer. 50 anim)) 
+    (.start (Timer. 50 anim))
     (.pack frame)
     (.setVisible frame true))
   )

--- a/src/test/clojure/clojure/core/matrix/demo/pagerank.clj
+++ b/src/test/clojure/clojure/core/matrix/demo/pagerank.clj
@@ -1,8 +1,8 @@
 (ns clojure.core.matrix.demo.pagerank
   (:refer-clojure :exclude [* - + / ==])
-  (:require clojure.core.matrix.impl.ndarray)
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.operators))
+  (:require clojure.core.matrix.impl.ndarray
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.operators :refer :all]))
 
 (defn demo []
 
@@ -13,7 +13,7 @@
 ;;   - http://en.wikipedia.org/wiki/PageRank
 
 (def links
-;; link matrix: each row represnts the number of 
+;; link matrix: each row represnts the number of
 ;; outbound links from a page to other pages
   [[0 0 1 1 0 0 1 2 0 0]
    [1 0 0 1 0 0 0 0 0 0]
@@ -28,7 +28,7 @@
 
 (def n (row-count links))
 
-(defn proportions 
+(defn proportions
   "Normalises a vector to a sum of 1.0"
   ([v]
     (/ v (esum v))))
@@ -51,14 +51,14 @@ outbound
 ;; Iterative method
 ;;
 ;; state defines the location of the browsing population
-;; each iteration of the pagerank sequences gets 
+;; each iteration of the pagerank sequences gets
 ;; closer to the correct pagerank value
 
-(def initial-state (proportions (repeat n 1000000))) 
+(def initial-state (proportions (repeat n 1000000)))
 (pm initial-state)
 
-(defn step 
-  "Compute the next state, i.e. the proportion of people 
+(defn step
+  "Compute the next state, i.e. the proportion of people
    on each page"
   ([state]
     (+ (* CLICK-THROUGH         (mmul inbound state))
@@ -84,15 +84,15 @@ outbound
 (pm (- (nth pageranks 100) (nth pageranks 300)))
 
 ;; make array out of sequence of steps
-(pm (array (take 8 pageranks))) 
+(pm (array (take 8 pageranks)))
 
 ;; =================================================================================
 ;; Direct (algebraic) method
 
-(defn pagerank-direct 
+(defn pagerank-direct
   "Computes the pagerank directly"
   ([inbound]
-    (mmul (inverse (- (identity-matrix n) 
+    (mmul (inverse (- (identity-matrix n)
                       (* CLICK-THROUGH inbound)))
           (* (- 1.0 CLICK-THROUGH) initial-state))))
 

--- a/src/test/clojure/clojure/core/matrix/demo/snakes.clj
+++ b/src/test/clojure/clojure/core/matrix/demo/snakes.clj
@@ -1,10 +1,10 @@
 (ns clojure.core.matrix.demo.snakes
-  (:use [clojure.core.matrix]))
+  (:require [clojure.core.matrix :refer :all]))
 
 (def start (vec (cons 1.0 (repeat 100 0.0))))
 
 (def snakes {16 6,
-             49 11, 
+             49 11,
              47 26,
              56 53,
              62 19,
@@ -21,7 +21,7 @@
               36 44,
               28 84,
               51 67,
-              71 91, 
+              71 91,
               80 100})
 
 (def snakes-and-ladders (merge snakes ladders))

--- a/src/test/clojure/clojure/core/matrix/generators.clj
+++ b/src/test/clojure/clojure/core/matrix/generators.clj
@@ -1,10 +1,6 @@
 (ns clojure.core.matrix.generators
-  (:use clojure.core.matrix)
-  (:use clojure.test)
-  (:require [clojure.test.check :as sc]
-            [clojure.test.check.generators :as gen]
-            [clojure.test.check.properties :as prop]
-            [clojure.test.check.clojure-test :as ct :refer (defspec)]))
+  (:require [clojure.test.check.generators :as gen]
+            [clojure.core.matrix :refer :all]))
 
 ;; =============================================================================
 ;; Array generators for test.check generative testing
@@ -14,7 +10,7 @@
 (def gen-double (gen/fmap double gen/ratio))
 
 
-(defn gen-nested-vectors 
+(defn gen-nested-vectors
   "Generator for nested vectors in a given shape, using a specified element generator"
   ([shape elem-gen]
     (reduce (fn [g s] (gen/vector g s)) elem-gen (reverse shape))))
@@ -22,7 +18,7 @@
 (defn gen-shape
   "Generator for valid core.matrix array shapes."
   ([] (gen/vector gen/s-pos-int))
-  ([& {:keys [dimensionality]}] (gen/vector gen/s-pos-int dimensionality))) 
+  ([& {:keys [dimensionality]}] (gen/vector gen/s-pos-int dimensionality)))
 
 (defn gen-array
   "Generator for arbitrary n-dimensional arrays"

--- a/src/test/clojure/clojure/core/matrix/impl/dummy.clj
+++ b/src/test/clojure/clojure/core/matrix/impl/dummy.clj
@@ -1,9 +1,9 @@
 (ns clojure.core.matrix.impl.dummy
-  (:use clojure.core.matrix)
-  (:use clojure.test)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.compliance-tester])
-  (:require [clojure.core.matrix.implementations :as imp]))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.compliance-tester]
+            [clojure.core.matrix.implementations :as imp]
+            [clojure.core.matrix :refer :all]
+            [clojure.test :refer :all]))
 
 (defrecord Dummy [dims])
 

--- a/src/test/clojure/clojure/core/matrix/impl/test_wrappers.clj
+++ b/src/test/clojure/clojure/core/matrix/impl/test_wrappers.clj
@@ -1,11 +1,10 @@
 (ns clojure.core.matrix.impl.test-wrappers
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.impl.wrappers)
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [mikera.cljutils.error :refer [error?]])
-  (:require [clojure.core.matrix.compliance-tester]))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [mikera.cljutils.error :refer [error?]]
+            [clojure.core.matrix.compliance-tester :as compliance]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.impl.wrappers :refer :all]
+            [clojure.test :refer :all]))
 
 (deftest regressions
   (is (str (wrap-slice [[1 2] [3 4]] 1))))
@@ -68,7 +67,7 @@
 
 (deftest test-wrap-fill
   (let [a (wrap-nd [[1 2] [3 4]])]
-    (is (equals [[9 9] [9 9]] (fill a 9))))) 
+    (is (equals [[9 9] [9 9]] (fill a 9)))))
 
 (deftest test-as-vector
   (is (e== [1] (as-vector (wrap-scalar 1)))))
@@ -102,8 +101,7 @@
   (is (equals [[1 3] [2 4]] (transpose (wrap-nd [[1 2] [3 4]])))))
 
 (deftest instance-tests
-  (clojure.core.matrix.compliance-tester/instance-test (wrap-scalar 1))
-  (clojure.core.matrix.compliance-tester/instance-test (wrap-slice [[1 2] [3 4]] 1))
-  (clojure.core.matrix.compliance-tester/instance-test (wrap-submatrix [[1 2] [3 4]] [[1 1] [0 1]]))
-  (clojure.core.matrix.compliance-tester/instance-test (wrap-nd [[1 2] [3 4]])))
-
+  (compliance/instance-test (wrap-scalar 1))
+  (compliance/instance-test (wrap-slice [[1 2] [3 4]] 1))
+  (compliance/instance-test (wrap-submatrix [[1 2] [3 4]] [[1 1] [0 1]]))
+  (compliance/instance-test (wrap-nd [[1 2] [3 4]])))

--- a/src/test/clojure/clojure/core/matrix/inline_benchmark.clj
+++ b/src/test/clojure/clojure/core/matrix/inline_benchmark.clj
@@ -1,6 +1,5 @@
 (ns clojure.core.matrix.inline-benchmark
-  (:require [criterium.core :as c])
-  (:import [clojure.core.matrix ClassPair]))
+  (:require [criterium.core :as c]))
 
 ;; benchmark for inline usage
 
@@ -11,11 +10,11 @@
   ([x y]
     (+ x y)))
 
-(defn add-prim 
+(defn add-prim
   (^long [^long x ^long y]
     (+ x y)))
 
-(defn add-inline 
+(defn add-inline
   {:inline (fn ([x y] `(+ ~x ~y)))}
   ([x y]
     (+ x y)))
@@ -26,7 +25,7 @@
 (defn length-hinted
   ([^String x] (.length x)))
 
-(defn length-inline 
+(defn length-inline
   {:inline (fn ([x] `(.length ~x)))}
   ([x]
     (.length x)))
@@ -46,22 +45,22 @@
 
   ;; primitive fn - 1.25 ns per call
   (c/quick-bench (dotimes [i 1000] (add-prim i 10)))
-  
+
   ;; inline fn - 1.19 ns per call
   (c/quick-bench (dotimes [i 1000] (add-inline i 10)))
-  
-  
+
+
   ;;========================================================
   ;; fn with relection - 2060 ns per call
   (c/quick-bench (dotimes [i 1000] (length-fn "foo")))
 
   ;; fn with type hints - 0.90 ns per call
   (c/quick-bench (dotimes [i 1000] (length-hinted "foo")))
-  
+
   ;; inline fn - 0.60 ns per call
   (c/quick-bench (dotimes [i 1000] (length-inline "foo")))
-  
-  
+
+
   ;;========================================================
   ;; wrapped fn count: 1.50 ns per call    (why is this so fast?!?)
   (c/quick-bench (dotimes [i 1000] (count-fn [1 2 3])))

--- a/src/test/clojure/clojure/core/matrix/properties.clj
+++ b/src/test/clojure/clojure/core/matrix/properties.clj
@@ -1,12 +1,11 @@
 (ns clojure.core.matrix.properties
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.linear)
-  (:use clojure.core.matrix.generators)
-  (:use clojure.test)
-  (:require [clojure.test.check :as sc]
+  (:require [clojure.test :refer :all]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
-            [clojure.test.check.clojure-test :as ct :refer (defspec)]))
+            [clojure.test.check.clojure-test :refer (defspec)]
+            [clojure.core.matrix.generators :as genm]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.linear :refer :all]))
 
 ;; Property based testing of randomly generated core.matrix arrays
 
@@ -107,7 +106,7 @@
 
 (defspec qr-props num-tests
   (prop/for-all
-   [mtx (gen-matrix)]
+   [mtx (genm/gen-matrix)]
    (if (>= (row-count mtx) (column-count mtx)) ;; TODO: fix when rows < cols is supported
      (if-let [{:keys [Q R]} (qr mtx)]
        (do  (is (orthogonal? Q))

--- a/src/test/clojure/clojure/core/matrix/query_benchmark.clj
+++ b/src/test/clojure/clojure/core/matrix/query_benchmark.clj
@@ -1,8 +1,7 @@
 (ns clojure.core.matrix.query-benchmark
-  (:require [criterium.core :as c])
-  (:use clojure.core.matrix)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:import [clojure.core.matrix ClassPair]))
+  (:require [criterium.core :as c]
+            [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix :refer :all]))
 
 ;; benchmark for querying array properties
 

--- a/src/test/clojure/clojure/core/matrix/test_api.clj
+++ b/src/test/clojure/clojure/core/matrix/test_api.clj
@@ -1,15 +1,16 @@
 (ns clojure.core.matrix.test-api
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.utils)
-  (:use clojure.core.matrix.select)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.linear :as li])
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require clojure.core.matrix.examples)
-  (:require clojure.core.matrix.impl.persistent-vector)
   (:refer-clojure :exclude [vector?])
-  (:use clojure.test))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.linear :as li]
+            [clojure.core.matrix.operators :as op]
+            [clojure.core.matrix.implementations :as imp]
+            clojure.core.matrix.examples
+            clojure.core.matrix.impl.persistent-vector
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.utils :refer [error? broadcast-shape]]
+            [clojure.core.matrix.select :refer :all]
+            [clojure.test :refer :all])
+  (:import [java.io StringWriter]))
 
 ;; This namespace is intended for general purpose tests og the core.matrix API functions
 
@@ -24,7 +25,7 @@
     (let [m [[7 8] [9 10]]]
       (is (== 0 (label m 0 0)))
       (is (== 1 (label m 0 1)))
-      (is (error? (label m 0 2)))))) 
+      (is (error? (label m 0 2))))))
 
 (deftest test-select
   (let [a [[1 2] [3 4]]]
@@ -60,8 +61,8 @@
 (deftest test-set-selection
   (let [a [[1 2 3 4] [5 6 7 8] [9 10 11 12]]]
     (testing "set-selection"
-      (is (= [[2 2 3 4] [5 6 7 8] [9 10 11 12]]) (set-selection a 0 0 2))
-      (is (= [[3 2 3 3] [5 6 7 8] [3 10 11 3]]) (set-selection a [0 2] [0 3] 3)))))
+      (is (= [[2 2 3 4] [5 6 7 8] [9 10 11 12]] (set-selection a 0 0 2)))
+      (is (= [[3 2 3 3] [5 6 7 8] [3 10 11 3]] (set-selection a [0 2] [0 3] 3))))))
 
 (deftest test-set-selection!
   (let [a (matrix :ndarray [[1 2 3 4] [5 6 7 8] [9 10 11 12]])]
@@ -75,10 +76,10 @@
 (deftest test-set-sel
   (let [a [[1 2 3 4] [5 6 7 8] [9 10 11 12]]]
     (testing "set-sel"
-      (is (= [[2 2 3 4] [5 6 7 8] [9 10 11 12]]) (set-sel a 0 0 2))
-      (is (= [[3 2 3 3] [5 6 7 8] [3 10 11 3]]) (set-sel a [0 2] [0 3] 3))
-      (is (= [[1 2 3 4] [5 5 5 5] [5 5 5 5]])
-          (set-sel a (where (partial < 5)) 5)))))
+      (is (= [[2 2 3 4] [5 6 7 8] [9 10 11 12]] (set-sel a 0 0 2)))
+      (is (= [[3 2 3 3] [5 6 7 8] [3 10 11 3]] (set-sel a [0 2] [0 3] 3)))
+      (is (= [[1 2 3 4] [5 5 5 5] [5 5 5 5]]
+             (set-sel a (where (partial < 5)) 5))))))
 
 (deftest test-set-sel!
   (let [a (matrix :ndarray [[1 2 3 4] [5 6 7 8] [9 10 11 12]])]
@@ -138,7 +139,7 @@
   (is (equals [3 8] (add-product [0 0] [1 2] [3 4]))))
 
 (deftest test-reshape
-  (is (equals [[0 1] [2 3] [4 5]] (reshape (range 6) [3 2])))) 
+  (is (equals [[0 1] [2 3] [4 5]] (reshape (range 6) [3 2]))))
 
 (deftest test-square
   (is (equals 81 (square 9)))
@@ -218,7 +219,7 @@
   (is (equals [[3]] (submatrix (array [[1 2] [3 4]]) [[1 1] [0 1]])))
   (is (equals [[2] [4]] (submatrix (array [[1 2] [3 4]]) 1 [1 1])))
   (is (equals [2 3] (submatrix (array [1 2 3 4]) [[1 2]])))
-  (is (equals [[4]] (submatrix [[1 2] [3 4]] 1 1 1 1))) 
+  (is (equals [[4]] (submatrix [[1 2] [3 4]] 1 1 1 1)))
   (is (equals [2 3] (submatrix (array [1 2 3 4]) 0 [1 2]))))
 
 (deftest test-element-seq
@@ -407,7 +408,7 @@
   ;; (is (e== [1 4] (diagonal [[1 2] [3 4]] 0)))
   ;; (is (e== [2] (diagonal [[1 2] [3 4]] 1)))
   ;; (is (e== [3] (diagonal [[1 2] [3 4]] -1)))
-  ) 
+  )
 
 (deftest test-diagonal
   (is (= [1 4] (diagonal [[1 2] [3 4] [5 6]]   )))
@@ -494,7 +495,7 @@
     (is (e== [0 1] (sub [1 2] 1.0)))
     (is (e== [0 -1] (sub 1.0 [1 2])))))
 
-(deftest test-sparsity 
+(deftest test-sparsity
   (testing "sparse?"
     (is (not (sparse? [0 1 2]))))
   (testing "density"
@@ -516,19 +517,19 @@
   (is (= [[1 0.0 0.0] [0.0 2 3] [0.0 4 5]] (block-diagonal-matrix [[[1]][[2 3][4 5]]]))))
 
 (deftest test-non-zero-indices
-  (is (= []                                    
+  (is (= []
          (non-zero-indices [0])))
-  (is (= [0]                                   
+  (is (= [0]
          (non-zero-indices [1])))
-  (is (= [0 3 4]                               
+  (is (= [0 3 4]
          (non-zero-indices [1 0 0 2 5 0])))
-  (is (= [[[0]] [[]] [[0]] [[]]]               
+  (is (= [[[0]] [[]] [[0]] [[]]]
          (non-zero-indices [[[1.0]][[0]][[9.0]][[0]]])))
-  (is (= [[[1] [1]] [[0 1] [0]] [[0 1] [0 1]]] 
+  (is (= [[[1] [1]] [[0 1] [0]] [[0 1] [0 1]]]
          (non-zero-indices [[[0.0 2.0][0 4.0]][[5.0 6.0][7.0 0]][[9.0 10.0][11.0 12.0]]]))))
 
 (deftest check-examples
-  (binding [*out* (java.io.StringWriter.)]
+  (binding [*out* (StringWriter.)]
     (testing "example code"
       (clojure.core.matrix.examples/all-examples))))
 
@@ -620,9 +621,9 @@
   (is (= 30.0 (li/norm (matrix [[1 2][3 4]]) 2)))
   (is (= 10.0 (li/norm (matrix [[1 2][3 4]]) 1)))
   (is (= 100.0 (li/norm (matrix [[1 2][3 4]]) 3)))
-  (is (= 4 (li/norm (matrix [[1 2][3 4]]) java.lang.Double/POSITIVE_INFINITY)))
+  (is (= 4 (li/norm (matrix [[1 2][3 4]]) Double/POSITIVE_INFINITY)))
   (is (= 30.0 (li/norm (vector 1 2 3 4))))
   (is (= 30.0 (li/norm (vector 1 2 3 4) 2)))
   (is (= 10.0 (li/norm (vector 1 2 3 4) 1)))
   (is (= 100.0 (li/norm (vector 1 2 3 4) 3)))
-  (is (= 4 (li/norm (vector 1 2 3 4) java.lang.Double/POSITIVE_INFINITY))))
+  (is (= 4 (li/norm (vector 1 2 3 4) Double/POSITIVE_INFINITY))))

--- a/src/test/clojure/clojure/core/matrix/test_arrays.clj
+++ b/src/test/clojure/clojure/core/matrix/test_arrays.clj
@@ -1,11 +1,9 @@
 (ns clojure.core.matrix.test-arrays
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.compliance-tester])
   (:refer-clojure :exclude [vector?])
-  (:use clojure.test))
+  (:require [clojure.core.matrix.compliance-tester :as compliance]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.utils :refer :all]
+            [clojure.test :refer :all]))
 
 ;; This namespace is intended for tests of core.matrix functions on arbitrary Java arrays
 ;;
@@ -23,18 +21,15 @@
   (let [a (long-array [1 2 3])]
     (is (== 1 (first (slices a)))))
   (let [a (object-array [1 2 3])]
-    (is (array? (first (slice-views a)))))) 
+    (is (array? (first (slice-views a))))))
 
 (deftest compliance-tests
-  (clojure.core.matrix.compliance-tester/instance-test (int-array [1 2 3]))
-  (clojure.core.matrix.compliance-tester/instance-test (float-array [1 2 3]))
-  (clojure.core.matrix.compliance-tester/instance-test (long-array []))
-  (clojure.core.matrix.compliance-tester/instance-test (char-array [\a \b \c]))
-  (clojure.core.matrix.compliance-tester/instance-test (object-array [(double-array [1 2 3])]))
-  ;; TODO: reinstante once Clojure bug CLJ-1306 is fixed
-  ;; (clojure.core.matrix.compliance-tester/instance-test (object-array [(short-array (map short [1 2 3]))]))
-  (clojure.core.matrix.compliance-tester/instance-test 
-    (into-array (Class/forName "[D") 
-                [(double-array [1 2])
-                 (double-array [3 4])]))
-  )
+  (compliance/instance-test (int-array [1 2 3]))
+  (compliance/instance-test (float-array [1 2 3]))
+  (compliance/instance-test (long-array []))
+  (compliance/instance-test (char-array [\a \b \c]))
+  (compliance/instance-test (object-array [(double-array [1 2 3])]))
+  (compliance/instance-test (object-array [(short-array (map short [1 2 3]))]))
+  (compliance/instance-test (into-array (Class/forName "[D")
+                                        [(double-array [1 2])
+                                         (double-array [3 4])])))

--- a/src/test/clojure/clojure/core/matrix/test_dataset.clj
+++ b/src/test/clojure/clojure/core/matrix/test_dataset.clj
@@ -1,12 +1,9 @@
 (ns clojure.core.matrix.test-dataset
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.dataset)
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.impl.dataset :as ds])
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.compliance-tester]))
+  (:require [clojure.core.matrix.impl.dataset :as ds]
+            [clojure.core.matrix.compliance-tester :as compliance]
+            [clojure.test :refer :all]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.dataset :refer :all]))
 
 (deftest test-construct-dataset
   (let [ds1 (dataset [:a :b] (matrix [[1 4] [2 5] [3 6]]))
@@ -92,8 +89,8 @@
     (is (= (row-maps ds) [{:a 1 :b 4} {:a 2 :b 5} {:a 3 :b 6}]))))
 
 (deftest instance-tests
-  (clojure.core.matrix.compliance-tester/instance-test
+  (compliance/instance-test
    (ds/dataset-from-columns [:bar] [["Foo"]])))
 
 (deftest compliance-test
-  (clojure.core.matrix.compliance-tester/compliance-test ds/CANONICAL-OBJECT))
+  (compliance/compliance-test ds/CANONICAL-OBJECT))

--- a/src/test/clojure/clojure/core/matrix/test_double_array.clj
+++ b/src/test/clojure/clojure/core/matrix/test_double_array.clj
@@ -1,11 +1,9 @@
 (ns clojure.core.matrix.test-double-array
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.compliance-tester])
-  (:require clojure.core.matrix.impl.double-array))
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.compliance-tester]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.utils :refer [error?]]
+            [clojure.test :refer :all]))
 
 ;; This namespace contains tests for the Java double[] array implementation
 ;;
@@ -62,7 +60,7 @@
           fs (first (slice-views da))]
       (is (not (scalar? fs)))
       (is (== 0 (dimensionality fs)))
-      (fill! fs 10) 
+      (fill! fs 10)
       (is (equals [10 2 3] da))
       (is (array? fs))))
   (testing "wrong dimension"
@@ -89,7 +87,7 @@
       (is (= [2.0 4.0] (seq da)))))
   (testing "assign from a Number array"
     (let [da (double-array [1 2])]
-      (mp/assign-array! da (into-array java.lang.Number [2 5]))
+      (mp/assign-array! da (into-array Number [2 5]))
       (is (= [2.0 5.0] (seq da))))))
 
 (deftest test-equals

--- a/src/test/clojure/clojure/core/matrix/test_generated_arrays.clj
+++ b/src/test/clojure/clojure/core/matrix/test_generated_arrays.clj
@@ -1,17 +1,17 @@
 (ns clojure.core.matrix.test-generated-arrays
-  (:use clojure.core.matrix)
-  (:use clojure.test)
-  (:require [clojure.core.matrix.compliance-tester])
-  (:require [clojure.core.matrix.generators :as g])
-  (:require [clojure.test.check :as sc]
+  (:require [clojure.core.matrix.compliance-tester :as compliance]
+            [clojure.core.matrix.generators :as g]
+            [clojure.core.matrix :refer :all]
+            [clojure.test :refer :all]
+            [clojure.test.check :as sc]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
-            [clojure.test.check.clojure-test :as ct :refer (defspec)]))
+            [clojure.test.check.clojure-test :refer (defspec)]))
 
-(def instance-tests 
-  (prop/for-all [a (g/gen-array)] 
-                (when (supports-shape? a (shape a))
-                  (clojure.core.matrix.compliance-tester/instance-test a))))
+(def instance-tests
+  (prop/for-all [a (g/gen-array)]
+    (when (supports-shape? a (shape a))
+      (compliance/instance-test a))))
 
 (deftest generated-instance-tests
   (is (sc/quick-check 20 instance-tests :seed 2964321771959749102)))

--- a/src/test/clojure/clojure/core/matrix/test_index.clj
+++ b/src/test/clojure/clojure/core/matrix/test_index.clj
@@ -1,7 +1,6 @@
 (ns clojure.core.matrix.test-index
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.utils))
+  (:require [clojure.test :refer :all]
+            [clojure.core.matrix :refer :all]))
 
 (deftest test-int-index
   (let [xs (int-array [1 2 3])]

--- a/src/test/clojure/clojure/core/matrix/test_multimethods.clj
+++ b/src/test/clojure/clojure/core/matrix/test_multimethods.clj
@@ -1,8 +1,6 @@
 (ns clojure.core.matrix.test-multimethods
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:require [clojure.core.matrix.multimethods :as mm])
-  (:require clojure.core.matrix.impl.persistent-vector))
+  (:require [clojure.core.matrix.multimethods :as mm]
+            [clojure.test :refer :all]))
 
 (deftest test-hierarchy
   (testing "multimethod hierarchy"

--- a/src/test/clojure/clojure/core/matrix/test_ndarray_implementation.clj
+++ b/src/test/clojure/clojure/core/matrix/test_ndarray_implementation.clj
@@ -1,17 +1,17 @@
 (ns clojure.core.matrix.test-ndarray-implementation
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.compliance-tester :as ct])
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.generic :as gen])
-  (:require clojure.core.matrix.impl.persistent-vector)
-  (:require [clojure.core.matrix.impl.ndarray])
-  (:require [clojure.core.matrix.impl.ndarray-magic :as magic])
-  (:require [clojure.core.matrix.impl.ndarray-macro :as macro])
-  (:use clojure.core.matrix.impl.ndarray)
-  (:use clojure.core.matrix.impl.ndarray-double)
-  (:use clojure.core.matrix.impl.ndarray-object))
+  (:require [clojure.core.matrix.operators :as op]
+            [clojure.core.matrix.compliance-tester :as ct]
+            [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix.generic :as gen]
+            clojure.core.matrix.impl.persistent-vector
+            [clojure.core.matrix.impl.ndarray]
+            [clojure.core.matrix.impl.ndarray-magic :as magic]
+            [clojure.core.matrix.impl.ndarray-macro :as macro]
+            [clojure.test :refer :all]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.impl.ndarray :refer :all]
+            [clojure.core.matrix.impl.ndarray-double :refer :all]
+            [clojure.core.matrix.impl.ndarray-object :refer :all]))
 
 ;; Tests for the NDArray implementation
 

--- a/src/test/clojure/clojure/core/matrix/test_nil.clj
+++ b/src/test/clojure/clojure/core/matrix/test_nil.clj
@@ -1,11 +1,9 @@
 (ns clojure.core.matrix.test-nil
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.compliance-tester])
   (:refer-clojure :exclude [vector?])
-  (:use clojure.test))
+  (:require [clojure.core.matrix.compliance-tester :as compliance]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.utils :refer [error?]]
+            [clojure.test :refer :all]))
 
 ;; Tests for the specific behaviour of core.matrix functions on the nil value (a scalar)
 
@@ -19,7 +17,7 @@
   (is (nil? (assign 1 nil)))
   (is (nil? (ereduce + nil))))
 
-(deftest test-nil 
+(deftest test-nil
   (is (nil? (transpose nil)))
   (is (== 0 (dimensionality nil)))
   (is (nil? (shape nil))))
@@ -31,7 +29,7 @@
   (is (e= [nil nil] (broadcast nil [2])))
   (is (e= [nil nil] (assign [1 2] nil))))
 
-(deftest test-join 
+(deftest test-join
   (is (e= [nil nil] (join [nil] [nil]))))
 
 (deftest test-set
@@ -40,4 +38,4 @@
   (is (error? (mset nil 2 3))))
 
 (deftest instance-tests
-  (clojure.core.matrix.compliance-tester/instance-test nil))
+  (compliance/instance-test nil))

--- a/src/test/clojure/clojure/core/matrix/test_numbers.clj
+++ b/src/test/clojure/clojure/core/matrix/test_numbers.clj
@@ -1,11 +1,9 @@
 (ns clojure.core.matrix.test-numbers
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.compliance-tester])
   (:refer-clojure :exclude [vector?])
-  (:use clojure.test))
+  (:require [clojure.core.matrix.compliance-tester :as compliance]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.utils :refer [error?]]
+            [clojure.test :refer :all]))
 
 ;; Tests for core.matrix functions on regular scalar numerical values
 
@@ -15,7 +13,7 @@
 
 (deftest test-sparse-dense
   (is (== 1 (sparse 1)))
-  (is (== 2 (dense 2)))) 
+  (is (== 2 (dense 2))))
 
 (deftest test-arithmentic
   (is (== 2 (add 1 1)))
@@ -33,20 +31,20 @@
 
 (deftest test-dot
   (is (== 10 (dot 2 5)))
-  (is (equals [3 6 9] (dot 3 [1 2 3])))) 
+  (is (equals [3 6 9] (dot 3 [1 2 3]))))
 
 (deftest test-rotate
   (testing "Rotate should be identity on scalar values"
     (is (== 3 (rotate 3 0 10)))
-    (is (== 3 (rotate 3 10 10))))) 
+    (is (== 3 (rotate 3 10 10)))))
 
 (deftest test-shape
   (is (== 1 (ecount 13)))
-  (is (nil? (shape 13)))) 
+  (is (nil? (shape 13))))
 
 (deftest test-min-max
   (is (== 3 (emin 3)))
-  (is (== 2 (emax 2)))) 
+  (is (== 2 (emax 2))))
 
 (deftest test-compute-matrix
   (is (equals 3 (compute-matrix [] (fn [] 3)))))
@@ -56,5 +54,5 @@
   (is (equals [2] (as-vector 2))))
 
 (deftest instance-tests
-  (clojure.core.matrix.compliance-tester/instance-test 0)
-  (clojure.core.matrix.compliance-tester/instance-test 1))
+  (compliance/instance-test 0)
+  (compliance/instance-test 1))

--- a/src/test/clojure/clojure/core/matrix/test_object_array.clj
+++ b/src/test/clojure/clojure/core/matrix/test_object_array.clj
@@ -1,11 +1,7 @@
 (ns clojure.core.matrix.test-object-array
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.compliance-tester])
-  (:require clojure.core.matrix.impl.double-array))
+  (:require [clojure.core.matrix.compliance-tester :as compliance]
+            [clojure.core.matrix :refer :all]
+            [clojure.test :refer :all]))
 
 ;; Tests for core.matrix functions on Java Object [] arrays
 ;;
@@ -21,9 +17,9 @@
 
 (deftest instance-tests
   ;(clojure.core.matrix.compliance-tester/instance-test (object-array []))
-  (clojure.core.matrix.compliance-tester/instance-test (object-array [1]))
-  (clojure.core.matrix.compliance-tester/instance-test (object-array [1 :foo]))
-  (clojure.core.matrix.compliance-tester/instance-test (object-array [-1 4 2 7 -3])))
+  (compliance/instance-test (object-array [1]))
+  (compliance/instance-test (object-array [1 :foo]))
+  (compliance/instance-test (object-array [-1 4 2 7 -3])))
 
-(deftest compliance-test
-  (clojure.core.matrix.compliance-tester/compliance-test (object-array [0.23])))
+(deftest compliance-tests
+  (compliance/compliance-test (object-array [0.23])))

--- a/src/test/clojure/clojure/core/matrix/test_operators.clj
+++ b/src/test/clojure/clojure/core/matrix/test_operators.clj
@@ -1,9 +1,9 @@
 (ns clojure.core.matrix.test-operators
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.operators)
-  (:require clojure.core.matrix.impl.persistent-vector)
-  (:refer-clojure :exclude [* - + / ==]))
+  (:refer-clojure :exclude [* - + / ==])
+  (:require clojure.core.matrix.impl.persistent-vector
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.operators :refer :all]
+            [clojure.test :refer :all]))
 
 ;; Tests for the clojure.core.matrix.operators namespace
 

--- a/src/test/clojure/clojure/core/matrix/test_persistent_vector_implementation.clj
+++ b/src/test/clojure/clojure/core/matrix/test_persistent_vector_implementation.clj
@@ -1,12 +1,12 @@
 (ns clojure.core.matrix.test-persistent-vector-implementation
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.impl.wrappers :as wrap])
-  (:require [clojure.core.matrix.compliance-tester])
-  (:require clojure.core.matrix.impl.persistent-vector)
-  (:refer-clojure :exclude [vector?]))
+  (:refer-clojure :exclude [vector?])
+  (:require [clojure.core.matrix.impl.wrappers :as wrap]
+            [clojure.core.matrix.compliance-tester]
+            clojure.core.matrix.impl.persistent-vector
+            [clojure.core.matrix.compliance-tester :as compliance]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.utils :refer [error?]]
+            [clojure.test :refer :all]))
 
 ;; Tests for the implementation of core.matrix on Clojure persistent vectors
 ;;
@@ -36,7 +36,7 @@
     (is (equals [[6 7] [8 9]] (emap + [[1 2] [3 4]] 5)))
     (is (equals [[6 7] [8 9]] (emap + 5 [[1 2] [3 4]])))))
 
-(deftest test-assign 
+(deftest test-assign
   (is (= [[1 2] [1 2]] (assign [[1 2] [3 4]] [1 2])))
   (is (error? (assign [1 2] [[1 2] [3 4]]))))
 
@@ -52,7 +52,7 @@
 
 (deftest test-fill
   (is (equals [[2 2] [2 2]] (fill [[1 2] [3 4]] 2)))
-  (is (equals [[2 2] [2 2]] (fill [[1 2] [3 4]] [2 2])))) 
+  (is (equals [[2 2] [2 2]] (fill [[1 2] [3 4]] [2 2]))))
 
 (deftest test-transpose
   (testing "vector transpose"
@@ -83,7 +83,7 @@
   (is (equals [2 4 6] (dot 2 [1 2 3])))
   (is (equals [2 4 6] (dot [1 2 3] 2)))
   (is (equals 20 (dot [1 2 3] [2 3 4])))
-  (is (equals [[1 2] [6 8]] (dot [[1 0] [0 2]] [[1 2] [3 4]])))) 
+  (is (equals [[1 2] [6 8]] (dot [[1 0] [0 2]] [[1 2] [3 4]]))))
 
 (deftest test-incompatible
   (is (error? (add [1 2] [3 4 5])))
@@ -204,7 +204,7 @@
 
 (deftest instance-tests
   (testing "empty persistent vectors are supported"
-    (clojure.core.matrix.compliance-tester/instance-test []))
+    (compliance/instance-test []))
   (testing "matrices of symbols are supported"
     (clojure.core.matrix.compliance-tester/instance-test ['a 'b]))
   (testing "matrices of heterogeneous submatrices"

--- a/src/test/clojure/clojure/core/matrix/test_pprint.clj
+++ b/src/test/clojure/clojure/core/matrix/test_pprint.clj
@@ -1,7 +1,7 @@
 (ns clojure.core.matrix.test-pprint
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:require [clojure.core.matrix.impl.pprint :as pp]))
+  (:require [clojure.core.matrix.impl.pprint :as pp]
+            [clojure.core.matrix :refer :all]
+            [clojure.test :refer :all]))
 
 (deftest test-basic-pprint
   (is (= "[1.000 2.000]" (pp/pm [1 2]))))

--- a/src/test/clojure/clojure/core/matrix/test_sequence.clj
+++ b/src/test/clojure/clojure/core/matrix/test_sequence.clj
@@ -1,12 +1,9 @@
 (ns clojure.core.matrix.test-sequence
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.compliance-tester])
-  (:require clojure.core.matrix.impl.sequence))
+  (:require [clojure.core.matrix.compliance-tester :as compliance]
+            [clojure.core.matrix :refer :all]
+            [clojure.test :refer :all]))
 
-;; Tests for core.matrix implementation for arbitray sequences (ISeq)
+;; Tests for core.matrix implementation for arbitrary sequences (ISeq)
 
 (deftest regressions
   (is (== 3 (ereduce (fn [acc _] (inc acc)) 0 '(nil nil nil))))
@@ -18,7 +15,7 @@
   (is (= [2 2] (shape '((1 2) (3 4))))))
 
 (deftest compliance-test
-  (clojure.core.matrix.compliance-tester/compliance-test '(1)))
+  (compliance/compliance-test '(1)))
 
 (deftest sequence-ops
   (is (equals (emul (range 10) (range 10)) '(0 1 4 9 16 25 36 49 64 81))))

--- a/src/test/clojure/clojure/core/matrix/test_sparse_map.clj
+++ b/src/test/clojure/clojure/core/matrix/test_sparse_map.clj
@@ -1,10 +1,7 @@
 (ns clojure.core.matrix.test-sparse-map
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.impl.wrappers :as wrap])
-  (:require [clojure.core.matrix.compliance-tester])
-  (:require [clojure.core.matrix.impl.sparse-map :as sm]))
+  (:require [clojure.core.matrix.compliance-tester :as compliance]
+            [clojure.core.matrix :refer :all]
+            [clojure.test :refer :all]))
 
 (defn sm
   [data]
@@ -21,9 +18,9 @@
 
 (deftest instance-tests
   (testing "matrices of symbols are supported"
-    (clojure.core.matrix.compliance-tester/instance-test (sm ['a 'b])))
+    (compliance/instance-test (sm ['a 'b])))
   (testing "matrices of heterogeneous submatrices"
-    (clojure.core.matrix.compliance-tester/instance-test (sm [[1 2.0] (double-array [3 4])]))))
+    (compliance/instance-test (sm [[1 2.0] (double-array [3 4])]))))
 
 (deftest compliance-test
-  (clojure.core.matrix.compliance-tester/compliance-test (sm [[1]])))
+  (compliance/compliance-test (sm [[1]])))

--- a/src/test/clojure/clojure/core/matrix/test_utils.clj
+++ b/src/test/clojure/clojure/core/matrix/test_utils.clj
@@ -1,13 +1,11 @@
 (ns clojure.core.matrix.test-utils
-  (:use clojure.test)
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require clojure.core.matrix.examples)
-  (:require clojure.core.matrix.impl.persistent-vector)
-  (:refer-clojure :exclude [vector?]))
+  (:refer-clojure :exclude [vector?])
+  (:require [clojure.core.matrix.protocols :as mp]
+            [clojure.core.matrix :refer :all]
+            [clojure.core.matrix.utils :refer [extends-deep? extract-protocols]]
+            [clojure.test :refer :all])
+  (:import [clojure.lang PersistentVector]
+           [mikera.vectorz Vector]))
 
 ;; Tests for clojure.core.matrix.utils functions and macros
 
@@ -16,11 +14,11 @@
   (is (= (count (long-array 0)) (count (long-array nil)))))
 
 (deftest test-protocol-extension
-  (is (extends-deep? clojure.core.matrix.protocols/PImplementation clojure.lang.PersistentVector))
-  (is (extends-deep? clojure.core.matrix.protocols/PImplementation mikera.vectorz.Vector))) 
+  (is (extends-deep? mp/PImplementation PersistentVector))
+  (is (extends-deep? mp/PImplementation Vector)))
 
 ;; this tests that all protocols have a default implementation for java.lang.Object
 ;; (except for specified known exceptions
 (deftest test-default-implementations
   (is (= #{'PIndexedSettingMutable 'PMatrixRank 'PGenericOperations 'PDatasetImplementation}
-         (set (map :name (filter #(not (extends? % java.lang.Object)) (extract-protocols)))))))
+         (set (map :name (filter #(not (extends? % Object)) (extract-protocols)))))))

--- a/src/test/clojure/clojure/core/matrix/test_vectorz.clj
+++ b/src/test/clojure/clojure/core/matrix/test_vectorz.clj
@@ -1,12 +1,10 @@
 (ns clojure.core.matrix.test-vectorz
-  (:use clojure.core.matrix)
-  (:use clojure.core.matrix.utils)
-  (:require [clojure.core.matrix.protocols :as mp])
-  (:require [clojure.core.matrix.implementations :as imp])
-  (:require [clojure.core.matrix.operators :as op])
-  (:require [clojure.core.matrix.compliance-tester])
-  (:require [mikera.vectorz.matrix-api])
-  (:use clojure.test))
+  (:require [clojure.core.matrix.impl.pprint :as pprint]
+            [mikera.vectorz.matrix-api]
+            [clojure.core.matrix.compliance-tester :as compliance]
+            [clojure.core.matrix :refer :all]
+            [clojure.test :refer :all])
+  (:import (mikera.arrayz INDArray)) )
 
 ;; Tests for the Vectorz implementation, an important high speed JVM array library
 ;;
@@ -16,17 +14,17 @@
 (deftest regression-201
   (let [m (matrix :vectorz [[2 2][2 2]])
         mm (mutable m)]
-    (is (instance? mikera.arrayz.INDArray mm))
+    (is (instance? INDArray mm))
     (is (equals [[4 4] [4 4]] (pow! mm 2)))))
 
 (deftest test-sparse
-  (is (instance? mikera.arrayz.INDArray (sparse (matrix :vectorz [[1 2] [3 4]]))))
-  (is (instance? mikera.arrayz.INDArray (sparse :vectorz [[1 2] [3 4]]))))
+  (is (instance? INDArray (sparse (matrix :vectorz [[1 2] [3 4]]))))
+  (is (instance? INDArray (sparse :vectorz [[1 2] [3 4]]))))
 
 (deftest test-pm
-  (is (string? (clojure.core.matrix.impl.pprint/pm (array :vectorz [1 2]))))) 
+  (is (string? (pprint/pm (array :vectorz [1 2])))))
 
 (deftest compliance-tests
-  (clojure.core.matrix.compliance-tester/instance-test (array :vectorz [1 2 3]))
-  (clojure.core.matrix.compliance-tester/instance-test (array :vectorz [[1 2] [3 4]]))
-  (clojure.core.matrix.compliance-tester/instance-test (array :vectorz [[[1 2] [3 4]] [[5 6] [7 8]]])))
+  (compliance/instance-test (array :vectorz [1 2 3]))
+  (compliance/instance-test (array :vectorz [[1 2] [3 4]]))
+  (compliance/instance-test (array :vectorz [[[1 2] [3 4]] [[5 6] [7 8]]])))

--- a/src/test/clojure/test/misc/test_load.clj
+++ b/src/test/clojure/test/misc/test_load.clj
@@ -1,11 +1,11 @@
 (ns test.misc.test-load
-  (:use [clojure.core.matrix.utils]))
+  (:require [clojure.core.matrix.utils :refer [error]]))
 
 (defn foo []
-  (doall 
-   (map deref (for [i (range 10)] 
-                (future 
-                  (require 'test.misc.loading-test) 
-                  (if (not (deref (resolve 'test.misc.loading-test/loaded))) 
+  (doall
+   (map deref (for [i (range 10)]
+                (future
+                  (require 'test.misc.loading-test)
+                  (if (not (deref (resolve 'test.misc.loading-test/loaded)))
                     (error "Not loaded!")
                     :OK))))))


### PR DESCRIPTION
This cleans up the namespaces, converting :uses to :requires, removing unused declarations, and making code more idiomatic.
