### PR TITLE
Changes suggested by running Eastwood lint tool, mostly enabling masked ...

### DIFF
--- a/src/main/clojure/clojure/core/matrix.clj
+++ b/src/main/clojure/clojure/core/matrix.clj
@@ -342,12 +342,13 @@
   ([implementation data]
     (or (mp/dense-coerce implementation data) (mp/coerce-param implementation data))))
 
-(defmacro with-implementation [impl & body]
+(defmacro with-implementation
   "Runs a set of expressions using a specified matrix implementation.
 
    Example:
      (with-implementation :vectorz
        (new-matrix 10 10))"
+  [impl & body]
   `(binding [imp/*matrix-implementation* (imp/get-canonical-object ~impl)]
      ~@body))
 
@@ -1585,12 +1586,14 @@
   ([f m a & more]
     (mp/element-map! m f a more) m))
 
-(defn index-seq-for-shape [sh]
+(defn index-seq-for-shape
   "Returns a sequence of all possible index vectors for a given shape, in row-major order"
+  [sh]
   (u/base-index-seq-for-shape sh))
 
-(defn index-seq [m]
+(defn index-seq
   "Returns a sequence of all possible index vectors into a matrix, in row-major order"
+  [m]
   (index-seq-for-shape (mp/get-shape m)))
 
 ;; =========================================================

--- a/src/main/clojure/clojure/core/matrix/compliance_tester.clj
+++ b/src/main/clojure/clojure/core/matrix/compliance_tester.clj
@@ -152,17 +152,17 @@
   (let [c (ecount m)]
     (when (pos? c)
       (when (supports-dimensionality? m 1)
-        (= (eseq m) (eseq (reshape m [c]))))
+        (is (= (eseq m) (eseq (reshape m [c])))))
       (when (supports-dimensionality? m 2)
-        (= (eseq m) (eseq (reshape m [1 c])))
-        (= (eseq m) (eseq (reshape m [c 1])))))))
+        (is (= (eseq m) (eseq (reshape m [1 c]))))
+        (is (= (eseq m) (eseq (reshape m [c 1]))))))))
 
 (defn test-broadcast [m]
   (let [c (ecount m)]
     (when (pos? c)
-      (e= m (first (slices (broadcast m (cons 2 (shape m))))))
-      (== c (ecount (broadcast m (cons 1 (shape m)))))
-      (== (* 3 c) (ecount (broadcast m (cons 3 (shape m))))))))
+      (is (e= m (first (slices (broadcast m (cons 2 (shape m)))))))
+      (is (== c (ecount (broadcast m (cons 1 (shape m))))))
+      (is (== (* 3 c) (ecount (broadcast m (cons 3 (shape m)))))))))
 
 (defn test-slice-assumptions [m]
   (let [dims (dimensionality m)]
@@ -344,19 +344,19 @@
   (testing "All supported sizes")
     (doseq [vm (create-supported-matrices im)]
       (let [m (matrix im vm)]
-        (e== vm m))))
+        (is (e== vm m)))))
 
 (defn test-coerce-via-vectors [m]
   (testing "Vector coercion"
     (when (supports-dimensionality? m 1)
       (testing "coerce works"
-        (or (= (imp/get-implementation-key m) (imp/get-implementation-key (coerce m [1])))))
+        (is (= (imp/get-implementation-key m) (imp/get-implementation-key (coerce m [1])))))
       (let [v (matrix [1])]
         (is (equals [1] (to-nested-vectors v))))))
   (testing "Matrix coercion"
     (when (supports-dimensionality? m 2)
       (testing "coerce works"
-        (or (= (imp/get-implementation-key m) (imp/get-implementation-key (coerce m [[1 2] [3 4]])))))
+        (is (= (imp/get-implementation-key m) (imp/get-implementation-key (coerce m [[1 2] [3 4]])))))
       (let [m (matrix [[1 2] [3 4]])]
         (is (equals [[1 2] [3 4]] (to-nested-vectors m))))))
 ;  (testing "Invalid vectors"
@@ -761,19 +761,20 @@
 
 (defn test-qr
   [im]
-  (map
-   #(let [m (matrix im %)
-          {:keys [Q R]} (qr m)]
-      (is (equals m (mmul Q R) 0.000001)))
-   [[[1 2 3 4]
-     [0 0 10 0]
-     [3 0 5 6]]
-    [[1 1 1
-      0 1 1
-      0 0 1]]]
-   [[1 7 3]
-    [7 4 -5]
-    [3 -5 6]])
+  (dorun
+   (map
+    #(let [m (matrix im %)
+           {:keys [Q R]} (qr m)]
+       (is (equals m (mmul Q R) 0.000001)))
+    [[[1 2 3 4]
+      [0 0 10 0]
+      [3 0 5 6]]
+     [[1 1 1
+       0 1 1
+       0 0 1]]
+     [[1 7 3]
+      [7 4 -5]
+      [3 -5 6]]]))
 
   (let [m (matrix im [[1 2] [3 4] [5 6] [7 8]])]
     (let [{:keys [R]} (qr m {:return [:R]

--- a/src/main/clojure/clojure/core/matrix/impl/double_array.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/double_array.clj
@@ -21,8 +21,9 @@
             :type-cast 'double
             :type-object Double/TYPE}})
 
-(defn new-double-array [shape]
+(defn new-double-array
   "Creates a new zero-filled nested double array of the given shape"
+  [shape]
   (let [dims (count shape)]
     (cond 
       (== 0 dims) 0.0

--- a/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
@@ -96,8 +96,9 @@
               (every? is-nested-persistent-vectors? x)
               (check-vector-shape x (mp/get-shape x))))))
 
-(defn persistent-vector-coerce [x]
+(defn persistent-vector-coerce
   "Coerces to nested persistent vectors"
+  [x]
   (let [dims (long (mp/dimensionality x))]
     (cond
       (> dims 0) (mp/convert-to-nested-vectors x) ;; any array with 1 or more dimensions
@@ -113,8 +114,9 @@
       ;; treat as a scalar value
       :default x)))
 
-(defn vector-dimensionality [m]
+(defn vector-dimensionality
   "Calculates the dimensionality (== nesting depth) of nested persistent vectors"
+  [m]
   (cond
     (clojure.core/vector? m)
       (if (> (count m) 0)

--- a/src/main/clojure/clojure/core/matrix/impl/wrappers.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/wrappers.clj
@@ -190,8 +190,9 @@
 ;; wraps an N-dimensional subset or broadcast of an array
 ;; supports aritrary permutations of dimensions and indexes
 
-(defmacro set-source-index [ix i val]
+(defmacro set-source-index
   "Sets up an index into the source vector for dimension i at position val"
+  [ix i val]
   (let [isym (gensym "i")]
     `(let [~isym ~i
            tdim# (aget ~'dim-map ~isym)]

--- a/src/main/clojure/clojure/core/matrix/protocols.clj
+++ b/src/main/clojure/clojure/core/matrix/protocols.clj
@@ -881,8 +881,9 @@
 ;; ============================================================
 ;; Utility functions
 
-(defn persistent-vector-coerce [x]
+(defn persistent-vector-coerce
   "Coerces a data structure to nested persistent vectors"
+  [x]
   (let [dims (long (dimensionality x))]
     (cond
       (== dims 0) (get-0d x) ;; first handle scalar / 0d case

--- a/src/main/clojure/clojure/core/matrix/utils.clj
+++ b/src/main/clojure/clojure/core/matrix/utils.clj
@@ -25,11 +25,6 @@
        (catch Throwable t#
          true))))
 
-(defmacro error
-  "Throws an error with the provided message(s)"
-  ([& vals]
-    `(throw (RuntimeException. (str ~@vals)))))
-
 ;; useful TODO macro: facilitates searching for TODO while throwing an error at runtime :-)
 (defmacro TODO
   ([] `(error "TODO: not yet implemented"))
@@ -168,8 +163,9 @@
       (doseq-indexed [x more i] (aset arr (+ 2 i) x))
       arr)))
 
-(defn base-index-seq-for-shape [sh]
+(defn base-index-seq-for-shape
   "Returns a sequence of all possible index vectors for a given shape, in row-major order"
+  [sh]
   (let [gen (fn gen [prefix rem]
               (if rem
                 (let [nrem (next rem)]

--- a/src/test/clojure/clojure/core/matrix/test_api.clj
+++ b/src/test/clojure/clojure/core/matrix/test_api.clj
@@ -198,8 +198,8 @@
       (is (equals [1.0 4.0 9.0] (pow a 2)))
       (is (equals [[1.0 4.0 9.0] [16.0 25.0 36.0] [49.0 64.0 81.0]] (pow m 2))))
     (testing "pow works when base is a scalar and exponent is an array"
-      (is (equals [5.0 25.0 125.0] (pow 5 a))
-          (equals [[2.0 4.0 8.0] [16.0 32.0 64.0] [128.0 256.0 512.0]] (pow 2 m))))
+      (is (equals [5.0 25.0 125.0] (pow 5 a)))
+      (is (equals [[2.0 4.0 8.0] [16.0 32.0 64.0] [128.0 256.0 512.0]] (pow 2 m))))
     (testing "pow works when both the base and the exponent are arrays"
       (is (equals [1.0 4.0 27.0] (pow a a)))
       (is (equals [[1.0 2.0 3.0] [16.0 25.0 36.0] [343.0 512.0 729.0]] (pow m a))))))
@@ -256,7 +256,7 @@
   (is (error? (scale! [1 2] 2)))
   (is (equals (scale! (mutable-matrix [1 2]) 2) [2 4])))
 
-(deftest test-reshape
+(deftest test-reshape-2
   (is (equals 1 (reshape [1 2 3] [])))
   (is (equals [1 2 3 4] (reshape [[1.0 2.0] [3.0 4.0]] [4])))
   (is (equals [1 2] (reshape [[1.0 2.0] [3.0 4.0]] [2])))
@@ -350,7 +350,7 @@
   (is (equals [2 1] (div 4 [2 4])))
   (is (equals [[1 2] [2 1]] (div [[4 8] [4 4]] [[4 4] [2 4]]))))
 
-(deftest test-pow
+(deftest test-pow-2
   (is (== 8 (pow 2 3)))
   (is (equals [0.5 2] (pow [2 0.5] -1))))
 
@@ -609,9 +609,9 @@
   (is (op/== (matrix [5 7])
              (op/+= (mutable (matrix [1 2]))
                     (matrix [4 5]))))
-  (is (op/== (matrix [-4 6]))
+  (is (op/== (matrix [-4 6])
              (op/-= (mutable (matrix [5 8]))
-                    (matrix [9 2])))
+                    (matrix [9 2]))))
   (is (op/== (matrix [6 8])
              (op/*= (mutable (matrix [3 2]))
                     (matrix [2 4]))))

--- a/src/test/clojure/clojure/core/matrix/test_ndarray_implementation.clj
+++ b/src/test/clojure/clojure/core/matrix/test_ndarray_implementation.clj
@@ -165,7 +165,7 @@
   ;(is (= 0 (gen/default-value :ndarray-long)))   ;; TODO add back when NDArray loading is fixed
   )
 
-(deftest regressions
+(deftest regressions-2
   (is (= 3 (-> [[1 2] [3 4]]
                array
                transpose

--- a/src/test/clojure/clojure/core/matrix/test_persistent_vector_implementation.clj
+++ b/src/test/clojure/clojure/core/matrix/test_persistent_vector_implementation.clj
@@ -131,19 +131,19 @@
 
 (deftest test-emap
   (testing "basic"
-    (equals [2 3] (emap inc [1 2])))
+    (is (equals [2 3] (emap inc [1 2]))))
   (testing "nested implementations"
-    (equals [[2 3]] (emap inc [(double-array [1 2])]))
-    (equals [[2 3]] (emap inc [[(wrap/wrap-scalar 1) (wrap/wrap-scalar 2)]]))))
+    (is (equals [[2 3]] (emap inc [(double-array [1 2])])))
+    (is (equals [[2 3]] (emap inc [[(wrap/wrap-scalar 1) (wrap/wrap-scalar 2)]])))))
 
 (deftest test-eseq
   (testing "basic"
-    (= [2 3] (eseq [2 3])))
+    (is (= [2 3] (eseq [2 3]))))
   (testing "nested implementations"
-    (= [1 2] (eseq [[1 2]]))
-    (= [1 2] (eseq [[1] [2]]))
-    (= [1 2] (eseq [(double-array [1 2])]))
-    (= [1 2] (eseq [[(wrap/wrap-scalar 1) (wrap/wrap-scalar 2)]]))))
+    (is (= [1 2] (eseq [[1 2]])))
+    (is (= [1 2] (eseq [[1] [2]])))
+    (is (= [1 2] (eseq [(double-array [1 2])])))
+    (is (= [1 2] (eseq [[(wrap/wrap-scalar 1) (wrap/wrap-scalar 2)]])))))
 
 (deftest test-contained-scalar-array
   (let [a [(scalar-array 1) 2]]


### PR DESCRIPTION
...tests

The core.matrix changes below were suggested by running the latest
unreleased version of Eastwood (after version 0.2.1) on a slightly
modified version of core.matrix.  The local modification to
core.matrix I made, _not_ included in this pull request, is hinted at
in issue #218, which I made to my local core.matrix copy to avoid the
crash it causes with Eastwood.  Eastwood still throws a couple of
exceptions on core.matrix after these changes, which I hope to fix in
a future release.

Most of these changes are straightforward, e.g.:
- doc strings belong before the arg vector, not after it.
- Added missing (is ...) forms around expressions in tests

File src/main/clojure/clojure/core/matrix/utils.clj:
- There were two identical definitions of the macro 'error'.  I
  deleted one.

Files src/test/clojure/clojure/core/matrix/test_api.clj and
src/test/clojure/clojure/core/matrix/test_ndarray_implementation.clj:
- Renamed some deftest Var's that were duplicates of earlier names,
  leading to some tests never being run.
  https://github.com/jonase/eastwood#redefd-vars

A few of these changes you should examine more carefully, as they may
not be what you want.

File src/main/clojure/clojure/core/matrix/compliance_tester.clj:
- Replaced a couple of calls to (or (= expr1 expr2)) with (is (= expr1
  expr2))
- Function test-qr had a call to map with (is ...) inside of the
  function, that was never getting called because map is lazy and the
  return value was discarded.  I added a doall around the map call to
  force evaluation of the result.  This caused an exception, and my
  guess is that the suggested change I have in this patch is what was
  desired: the args to map after the function should be a single
  vector of 3 matrices, not two vectors.

Before these changes, when I ran 'lein do clean, test' I saw:

Ran 234 tests containing 11794 assertions.
0 failures, 0 errors.

With these changes, I see:

Ran 237 tests containing 12384 assertions.
2 failures, 0 errors.

I haven't attempted to fix the failing tests, since you will probably
have a better idea how you would like to address those.  The test
failures are due to tests that were not being run before, and thus the
failures were masked.  They are not due to changes in behavior of the
(non-test) code.
