### PR TITLE
Corrected project.clj so codox (lein doc) works.  Added push-docs.bash t...

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,14 +11,14 @@
 
   :source-paths ["src/main/clojure"]
   :java-source-paths ["src/test/java"]
-
   :test-paths ["src/test/clojure" "src/test/java"]
-
-  :dependencies [[org.clojure/clojure "1.7.0-alpha4"]]
 
   :marginalia {:javascript ["http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"]}
 
-  :profiles {:dev {:dependencies [[net.mikera/cljunit "0.3.1"]
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0-alpha4"]
+                                  [net.mikera/cljunit "0.3.1"]
                                   [com.google.caliper/caliper "0.5-rc1"]
                                   [criterium/criterium "0.4.3"]
                                   [org.clojure/tools.macro "0.1.5"]
@@ -28,11 +28,13 @@
                    
                    :source-paths ["src/main/clojure" "src/dev/clojure"]
                    :jvm-opts ^:replace []}
-             :doc [:dev ;; composite profile, inherit from dev
-                   {:plugins [[codox "0.8.8"]]}]}
+
+             :doc {:dependencies [[org.clojure/clojure "1.6.0"]]
+                   :source-paths ["src/main/clojure"] } }
   
   :aliases {"doc" ["with-profile" "doc" "doc"]}
   
+  :plugins [[codox "0.8.10"]]
   :codox {:sources ["src/main/clojure"]
           :src-dir-uri "https://github.com/mikera/core.matrix/blob/master/"
           :src-linenum-anchor-prefix "L"

--- a/push-docs.bash
+++ b/push-docs.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Controlling values
+readonly projName="core.matrix"
+readonly ghPagesDir=${HOME}/gh-pages          # must be absolute pathname
+
+srcDir=$(pwd)/doc                       # absolute pathname of source
+destDir=${ghPagesDir}/${projName}       # absolute pathname of destination
+
+# Copy files
+rm -rf $destDir
+echo "Copying:  $srcDir  ->  $destDir"
+cp -pr          $srcDir      $destDir
+
+# Commit changes
+pushd ${ghPagesDir}
+  git add .
+  git commit --all -m"Update docs for $projName"
+  git push --set-upstream
+popd


### PR DESCRIPTION
I noticed that codox were not available for core.matrix, although I found some code for it in project.clj

I corrected project.clj so that codoc (lein doc) will work correctly, and added push-docs.bash to upload the doc files to GitHub Pages at http://cloojure.github.io/doc/core.matrix/    

If you'd like to increase my permissions, I could instead change it to the core.matrix GHP, or you could play around with the script yourself.

Alan
