### PR TITLE
Fixes #231 (emap throws exception for object-array with 3+ arguments)

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/object_array.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/object_array.clj
@@ -295,7 +295,7 @@
       ([m f a]
         (object-array (map #(mp/element-map %1 f %2) m (mp/get-major-slice-seq a))))
       ([m f a more]
-        (object-array (apply map #(apply mp/element-map %1 f %2 %&) m (mp/get-major-slice-seq a) (map mp/get-major-slice-seq more)))))
+        (object-array (apply map #(mp/element-map %1 f %2 %&) m (mp/get-major-slice-seq a) (map mp/get-major-slice-seq more)))))
     (element-map!
       ([m f]
         (dotimes [i (count m)]

--- a/src/test/clojure/clojure/core/matrix/test_object_array.clj
+++ b/src/test/clojure/clojure/core/matrix/test_object_array.clj
@@ -11,6 +11,15 @@
 (deftest regressions
   (is (= [2] (seq (emap inc (object-array [1]))))))
 
+(deftest test-functional-ops
+  (testing "map"
+    (let [oa  (object-array [1 2])
+          oa2 (object-array [3 4])
+          oa3 (object-array [5 6])]
+      (is (= [2 3] (seq (emap inc oa))))
+      (is (= [4 6] (seq (emap + oa oa2))))
+      (is (= [9 12] (seq (emap + oa oa2 oa3)))))))
+
 (deftest to-objects
   (is (equals [0 1 2] (to-object-array (range 3))))
   (is (e= [1 2 3 :foo] (to-object-array [[1 2] [3 :foo]]))))


### PR DESCRIPTION
I extracted here the fix for element-map not working on object-array when called with 3 or more arguments.
