### PR TITLE
dataset get-rows and row-maps optimized

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/dataset.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/dataset.clj
@@ -57,15 +57,15 @@
 (extend-protocol mp/PDimensionLabels
   DataSet
     (label [m dim i]
-      (cond 
+      (cond
         (== dim 1) (nth (:column-names m) i)
-        (<= 0 (long i) (dec (long (mp/dimension-count m dim)))) nil 
+        (<= 0 (long i) (dec (long (mp/dimension-count m dim)))) nil
         :else (error "Dimension index out of range: " i)))
     (labels [m dim]
-      (cond 
+      (cond
         (== dim 1) (:column-names m)
         (<= 0 (long dim) (dec (long (mp/dimensionality m)))) nil
-        :else (error "Dimension out of range: " dim)))) 
+        :else (error "Dimension out of range: " dim))))
 
 (extend-protocol mp/PMatrixSlices
   DataSet
@@ -86,8 +86,8 @@
 (extend-protocol mp/PMatrixRows
   DataSet
   (get-rows [ds]
-    (map #(mp/get-row ds %)
-         (range (mp/dimension-count ds 0)))))
+    (->> (mp/get-columns ds)
+         (apply map vector))))
 
 (extend-protocol mp/PColumnSetting
   DataSet
@@ -131,13 +131,8 @@
                           (conj (mp/get-columns ds) col)))
   (row-maps [ds]
     (let [col-names (mp/column-names ds)]
-      (map
-      (fn [row]
-        (->> (map-indexed
-              (fn [idx v] [(nth col-names idx) v])
-              row)
-             (into {})))
-      (mp/get-rows ds))))
+      (map #(zipmap col-names %)
+           (mp/get-rows ds))))
   (to-map [ds]
     (into {} (map (fn [k v] [k v])
                   (mp/column-names ds)


### PR DESCRIPTION
Setup:

``` Clojure
(use 'clojure.core.matrix)
(use 'clojure.core.matrix.dataset)
(use 'criterium.core)
(require '[clojure.test.check.generators :as gen])

(def tenk-longs (gen/sample (gen/choose 0 10) 10000))
(def tenk-strings (gen/sample (gen/elements ["foo" "bar" "baz" "qux"]) 10000))
(def test-dataset (dataset {:tenk-long tenk-longs :tenk-str tenk-strings}))
```

Before PR:

``` Clojure
user=> (quick-bench (vec (rows test-dataset)))
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 5.064131 sec
    Execution time std-deviation : 141.528594 ms
   Execution time lower quantile : 4.918339 sec ( 2.5%)
   Execution time upper quantile : 5.266684 sec (97.5%)
                   Overhead used : 1.958897 ns
```

After PR:

``` Clojure
user=> (quick-bench (vec (rows test-dataset)))
WARNING: Final GC required 2.750493198506586 % of runtime
WARNING: Final GC required 24.48785563202674 % of runtime
Evaluation count : 606 in 6 samples of 101 calls.
             Execution time mean : 998.546163 µs
    Execution time std-deviation : 52.533435 µs
   Execution time lower quantile : 945.488386 µs ( 2.5%)
   Execution time upper quantile : 1.048658 ms (97.5%)
                   Overhead used : 1.955636 ns
```

Before PR:

``` Clojure
user=> (quick-bench (vec (row-maps test-dataset)))
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 8.107962 sec
    Execution time std-deviation : 60.545940 ms
   Execution time lower quantile : 8.040001 sec ( 2.5%)
   Execution time upper quantile : 8.184063 sec (97.5%)
                   Overhead used : 1.958897 ns
```

After PR:

``` Clojure
user=> (quick-bench (vec (row-maps test-dataset)))
WARNING: Final GC required 23.09511999400084 % of runtime
Evaluation count : 192 in 6 samples of 32 calls.
             Execution time mean : 3.287454 ms
    Execution time std-deviation : 196.605760 µs
   Execution time lower quantile : 3.091381 ms ( 2.5%)
   Execution time upper quantile : 3.577013 ms (97.5%)
                   Overhead used : 1.955636 ns
```
