### PR TITLE
small typo in docs

### DIFF
--- a/src/main/clojure/clojure/core/matrix/linear.clj
+++ b/src/main/clojure/clojure/core/matrix/linear.clj
@@ -6,7 +6,7 @@
 (defn norm
   "Computes the norm of a matrix or vector.
 
-   By default calculates 2-norm for vectors and Frobenius 2-norm for matrices. The optinal p argument specifies use of the p-norm instead.
+   By default calculates 2-norm for vectors and Frobenius 2-norm for matrices. The optional p argument specifies use of the p-norm instead.
 
    Special cases of p argument:
    Double/POSITIVE_INFINITY - Infinity norm


### PR DESCRIPTION
Missing just an 'o'. Thanks for the great work!
