### PR TITLE
Implement PSelect protocol for persistent vector and Number classes

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -1807,7 +1807,9 @@
 (extend-protocol mp/PSelect
   Number
   (select [a area]
-    a))
+    (if (empty? area)
+      a
+      (error "Non empty area argument in select, called on Number " a))))
 
 (defn- area-indices [area]
   (reduce (fn [io in]

--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -1804,6 +1804,11 @@
   (select [a area]
     (wrap/wrap-selection a area)))
 
+(extend-protocol mp/PSelect
+  Number
+  (select [a area]
+    a))
+
 (defn- area-indices [area]
   (reduce (fn [io in]
             (for [a in b io]

--- a/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
@@ -630,6 +630,15 @@
         m))
   )
 
+(extend-protocol mp/PSelect
+  IPersistentVector
+    (select
+      ([a args]
+       (if (= (count args) 1)
+         (apply vector (mapv #(nth a %) (first args)))
+         (apply vector (mapv #(mp/select (nth a %) (next args))
+                             (first args)))))))
+
 ;; =====================================
 ;; Register implementation
 

--- a/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/persistent_vector.clj
@@ -634,8 +634,11 @@
   IPersistentVector
     (select
       ([a args]
-       (if (= (count args) 1)
-         (apply vector (mapv #(nth a %) (first args)))
+       (if (= 1 (count args))
+         (do
+           (if (= 1 (mp/dimensionality a))
+             (apply vector (mapv #(nth a %) (first args)))
+             (error "Array dimension does not match length of args")))
          (apply vector (mapv #(mp/select (nth a %) (next args))
                              (first args)))))))
 

--- a/src/test/clojure/clojure/core/matrix/test_numbers.clj
+++ b/src/test/clojure/clojure/core/matrix/test_numbers.clj
@@ -3,6 +3,7 @@
   (:require [clojure.core.matrix.compliance-tester :as compliance]
             [clojure.core.matrix :refer :all]
             [clojure.core.matrix.utils :refer [error?]]
+            [clojure.core.matrix.protocols :as mp]
             [clojure.test :refer :all]))
 
 ;; Tests for core.matrix functions on regular scalar numerical values
@@ -52,6 +53,14 @@
 (deftest test-broadcasting
   (is (equals [2 2 2] (broadcast 2 [3])))
   (is (equals [2] (as-vector 2))))
+
+(deftest test-select
+  (testing "mp/select on numbers with a non empty argument should throw an error"
+    (is (thrown? RuntimeException
+                 (mp/select 12 [[]]))))
+  (testing "calling select on numbers with an empty argument should return itself"
+    (is (= (select 1) 1))
+    (is (= (mp/select 0 []) 0))))
 
 (deftest instance-tests
   (compliance/instance-test 0)

--- a/src/test/clojure/clojure/core/matrix/test_persistent_vector_implementation.clj
+++ b/src/test/clojure/clojure/core/matrix/test_persistent_vector_implementation.clj
@@ -6,6 +6,7 @@
             [clojure.core.matrix.compliance-tester :as compliance]
             [clojure.core.matrix :refer :all]
             [clojure.core.matrix.utils :refer [error?]]
+            [clojure.core.matrix.protocols :as mp]
             [clojure.test :refer :all]))
 
 ;; Tests for the implementation of core.matrix on Clojure persistent vectors
@@ -209,6 +210,17 @@
   (is (error? (array [[1 2] [2 3 4]])))
   (is (error? (array [[1 2 3 4] [2 3 4]])))
   (is (error? (array [[1 2 3 4] 5]))))
+
+(deftest test-select
+  (let [m [[0 1 2 3] [4 5 6 7] [8 9 10 11]]]
+    (testing "proper select usage behaviour"
+      (is (= (select m :all :all) m))
+      (is (= (select m :all 0) [0 4 8]))
+      (is (= (select m [0 2] [1 3]) [[1 3] [9 11]])))
+    (testing "invalid argument to mp/select"
+      (is (thrown? RuntimeException (mp/select m [[0]]))))
+    (testing "invlaid argument to select"
+      (is (thrown? RuntimeException (select m nil))))))
 
 ;; run complicance tests
 


### PR DESCRIPTION
A recursive implementation for the mentioned issue. Also, i extend the `PSelect` protocol to return a scalar if `select` is called on a zero-dimension array (hence, returning itself).
