### PR TITLE
Fixes default clamp operation

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/default.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/default.clj
@@ -830,7 +830,9 @@
     (element-min [m] m)
     (element-max [m] m)
     (element-clamp [m a b]
-      (if (< m a) a (if (> m b) b m)))
+      (if-not (<= a b)
+        (error "min argument: " a " should be <= max argument: " b)
+        (if (< m a) a (if (> m b) b m))))
   Object
     (element-min [m]
       (mp/element-reduce m
@@ -841,10 +843,9 @@
                        (fn [best v] (if (or (not best) (> v best)) v best))
                        nil))
     (element-clamp [m a b]
-      (mp/element-map m 
-        (if (> a b)
-          (error "min argument: " a " must be less than max argument: " b)
-          (fn [e] (if (< e a) a (if (> e b) b e)))))))
+      (if-not (<= a b)
+        (error "min argument: " a " should be <= max argument: " b)
+        (mp/element-map m #(if (< %1 a) a (if (> %1 b) b %1))))))
 
 (extend-protocol mp/PCompare
   Number

--- a/src/test/clojure/clojure/core/matrix/test_api.clj
+++ b/src/test/clojure/clojure/core/matrix/test_api.clj
@@ -519,8 +519,7 @@
   (is (== 1 (emin [2 1 7])))
   (is (== 7 (emax [2 1 7])))
   (is (== 7 (emax [[4 3 2] [2 1 7] [-1 5 -20]])))
-  (is (equals [[2 5 2] [4 8 2] [5 6 3]] (clamp [[1 5 1] [4 10 2] [5 6 3]] 2 8)))
-  (is (error? (clamp [[1 2] [3 4]] 6 1))))
+  (is (equals [[2 5 2] [4 8 2] [5 6 3]] (clamp [[1 5 1] [4 10 2] [5 6 3]] 2 8))))
 
 (deftest test-predicates
   (testing "scalar predicates"

--- a/src/test/clojure/clojure/core/matrix/test_numbers.clj
+++ b/src/test/clojure/clojure/core/matrix/test_numbers.clj
@@ -45,7 +45,10 @@
 
 (deftest test-min-max
   (is (== 3 (emin 3)))
-  (is (== 2 (emax 2))))
+  (is (== 2 (emax 2)))
+  (is (== 2 (clamp 1 2 5)))
+  (is (== 5 (clamp 8 2 5)))
+  (is (error? (clamp 3 6 1))))
 
 (deftest test-compute-matrix
   (is (equals 3 (compute-matrix [] (fn [] 3)))))

--- a/src/test/clojure/clojure/core/matrix/test_persistent_vector_implementation.clj
+++ b/src/test/clojure/clojure/core/matrix/test_persistent_vector_implementation.clj
@@ -214,6 +214,9 @@
     (testing "invlaid argument to select"
       (is (thrown? RuntimeException (select m nil))))))
 
+(deftest test-clamp
+  (is (error? (clamp [[1 2] [3 4]] 6 1))))
+
 ;; run complicance tests
 
 (deftest instance-tests


### PR DESCRIPTION
Refactor check for ordering of min and max arguments to be outside element-map function in element-clamp. Also, added check for ordering of min and max arguments for scalars.

Remove test for error on unordered min & max arguments passed to clamp from API tests - some implementations may not want to implement this. Instead added tests for error on unordered min & max arguments passed to clamp to numbers and persistent-vector implementation tests.
