### PR TITLE
Fix ndarray-double matrixops return vals

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray.clj
@@ -315,7 +315,17 @@
 
 (magic/with-magic
   [:double]
-  (defn _lu-decompose!
+  (defn lu-decompose!
+    "LU-decomposition of a matrix into P A = L U. Saves L and U into
+     the input matrix as follows: L is a lower triangular part of it,
+     with diagonal omitted (they are all equal to 1); U is an upper
+     triangular part. P returned as a primitive int permutation array.
+     Returns a vector of two values: first is integer (-1)^n, where n is
+     a number of permutations, and second is a primitive int permutations
+     array. Returns nil if the matrix is singular
+     This function is translated from GNU linear algebra library, namely
+     `gsl_linalg_LU_decomp` (see [[lu]] for example). Python translation that
+     was used to implement this can be found at [[lupy]]."
     [^typename# m]
     (expose-ndarrays [m]
       (iae-when-not (== m-ndims 2)
@@ -328,62 +338,39 @@
             ;; sign of determinant
             sign (int-array [1])]
         ;; for all columns
-        (c-for [j (int 0) (< j (dec n)) (inc j)]
-          (let [i-pivot
-                (loop [i (inc j)
-                       max-i j
-                       max (Math/abs (aget-2d* m j j))]
-                  (if (< i n)
-                    (let [current (Math/abs (aget-2d* m i j))]
-                      (if (< max current)
-                        (recur (inc i) i current)
-                        (recur (inc i) max-i max)))
-                    (do (when (== max 0)
-                          (throw (ex-info "lu-decompose can't decompose singular matrix"
-                                          {:cause ::singular})))
-                        max-i)))
-                pivot (aget-2d* m i-pivot j)]
-            ;; when maximum element is not on diagonal, swap rows, update
-            ;; permutations and permutation counter
-            (when-not (== i-pivot j)
-              (c-for [k (int 0) (< k n) (inc k)]
-                (let [swap (aget-2d* m i-pivot k)]
-                  (aset-2d* m i-pivot k (aget-2d* m j k))
-                  (aset-2d* m j k swap)))
-              (let [swap (aget permutations i-pivot)]
-                (aset permutations i-pivot (aget permutations j))
-                (aset permutations j swap))
-              (aset sign 0 (* -1 (aget sign 0))))
-            (c-for [i (inc j) (< i n) (inc i)]
-              (let [scaled (/ (aget-2d* m i j) pivot)]
-                (aset-2d* m i j scaled)
-                (c-for [k (inc j) (< k n) (inc k)]
-                  (aset-2d* m i k (- (aget-2d* m i k)
-                                     (* (aget-2d* m j k)
-                                        scaled))))))))
-        [(aget sign 0) permutations]))))
-
-(magic/with-magic
-  [:double]
-  (defn lu-decompose!
-    "LU-decomposition of a matrix into P A = L U. Saves L and U into
-     the input matrix as follows: L is a lower triangular part of it,
-     with diagonal omitted (they are all equal to 1); U is an upper
-     triangular part. P returned as a primitive int permutation array.
-     Returns a vector of two values: first is integer (-1)^n, where n is
-     a number of permutations, and second is a primitive int permutations
-     array.
-     This function is translated from GNU linear algebra library, namely
-     `gsl_linalg_LU_decomp` (see [[lu]] for example). Python translation that
-     was used to implement this can be found at [[lupy]]."
-    [m]
-    (expose-ndarrays [m]
-      (try
-        (_lu-decompose!#t m)
-        (catch ExceptionInfo ex
-          (case (:cause (ex-data ex))
-            ::singular nil
-            (iae (.getMessage ex))))))))
+        (loop [j (int 0)]
+          (if (< j (dec n))
+            (let [[pivot i-pivot]
+                  (loop [i (inc j)
+                         max-i j
+                         max (Math/abs (aget-2d* m j j))]
+                    (if (< i n)
+                      (let [current (Math/abs (aget-2d* m i j))]
+                        (if (< max current)
+                          (recur (inc i) i current)
+                          (recur (inc i) max-i max)))
+                      [(aget-2d* m max-i j) max-i]))]
+              (when-not (== pivot 0)
+                ;; when maximum element is not on diagonal, swap rows, update
+                ;; permutations and permutation counter
+                (when-not (== i-pivot j)
+                  (c-for [k (int 0) (< k n) (inc k)]
+                    (let [swap (aget-2d* m i-pivot k)]
+                      (aset-2d* m i-pivot k (aget-2d* m j k))
+                      (aset-2d* m j k swap)))
+                  (let [swap (aget permutations i-pivot)]
+                    (aset permutations i-pivot (aget permutations j))
+                    (aset permutations j swap))
+                  (aset sign 0 (* -1 (aget sign 0))))
+                (c-for [i (inc j) (< i n) (inc i)]
+                  (let [scaled (/ (aget-2d* m i j) pivot)]
+                    (aset-2d* m i j scaled)
+                    (c-for [k (inc j) (< k n) (inc k)]
+                      (aset-2d* m i k (- (aget-2d* m i k)
+                                        (* (aget-2d* m j k)
+                                          scaled))))))
+                (recur (inc j))))
+            [(aget sign 0) permutations]))))))
 
 (magic/with-magic
   [:double]
@@ -434,18 +421,19 @@
             ^array-tag# x (array-cast# n)
             ^typename# lu (mp/clone m)
             ^typename# m-inverted (empty-ndarray#t [n n])
-            lu-output (_lu-decompose!#t lu) ; lu-decompose! mutates lu
+            lu-output (lu-decompose!#t lu) ; lu-decompose! mutates lu
             ^ints permutations (second lu-output)]
-        (expose-ndarrays [m-inverted]
-          (c-for [i (int 0) (< i n) (inc i)]
-            (c-for [j (int 0) (< j n) (inc j)]
-              (if (== (aget permutations j) i)
-                (aset x j (type-cast# 1))
-                (aset x j (type-cast# 0))))
-            (lu-solve!#t lu permutations x)
-            (c-for [j (int 0) (< j n) (inc j)]
-              (aset-2d* m-inverted j i (aget x j)))))
-        m-inverted))))
+        (when lu-output
+          (expose-ndarrays [m-inverted]
+            (c-for [i (int 0) (< i n) (inc i)]
+              (c-for [j (int 0) (< j n) (inc j)]
+                (if (== (aget permutations j) i)
+                  (aset x j (type-cast# 1))
+                  (aset x j (type-cast# 0))))
+              (lu-solve!#t lu permutations x)
+              (c-for [j (int 0) (< j n) (inc j)]
+                (aset-2d* m-inverted j i (aget x j)))))
+          m-inverted)))))
 
 (magic/with-magic
   [:double]
@@ -459,14 +447,16 @@
         "invert can operate only on square matrices")
       (let [n (aget m-shape 0)
             ^typename# lu (mp/clone m)
-            lu-output (_lu-decompose!#t lu) ; lu-decompose! mutates lu
+            lu-output (lu-decompose!#t lu) ; lu-decompose! mutates lu
             sign (first lu-output)]
-        (expose-ndarrays [lu]
-          (loop [i (int 0)
-                 det (type-cast# sign)]
-            (if (< i n)
-              (recur (inc i) (* det (aget-2d* lu i i)))
-              det)))))))
+        (if lu-output
+          (expose-ndarrays [lu]
+            (loop [i (int 0)
+                   det (type-cast# sign)]
+              (if (< i n)
+                (recur (inc i) (* det (aget-2d* lu i i)))
+                det)))
+          (type-cast# 0))))))
 
 (magic/extend-types
   [:long :float :double :object]
@@ -759,7 +749,7 @@
                            row-a 0
                            col-a 0]
                       (if (< row-a nrows)
-                        (if (< col-a ncols) 
+                        (if (< col-a ncols)
                           (if (== (aget data i-a) (aget data-b i-b))
                             (recur (+ i-a step-col-a) (+ i-b step-col-b)
                                    row-a (inc col-a))
@@ -1180,20 +1170,10 @@
         "determinant operates only on matrices")
       (iae-when-not (== (aget shape 0) (aget shape 1))
         "determinant operates only on square matrices")
-      (try
-        (determinant#t m)
-        (catch ExceptionInfo ex
-          (case (:cause (ex-data ex))
-            ::singular (type-cast# 0)
-            (iae (.getMessage ex))))))
+      (determinant#t m))
     (inverse [m]
       (iae-when-not (== ndims 2)
         "inverse operates only on matrices")
       (iae-when-not (== (aget shape 0) (aget shape 1))
         "inverse operates only on square matrices")
-      (try
-        (invert#t m)
-        (catch ExceptionInfo ex
-          (case (:cause (ex-data ex))
-            ::singular nil
-            (iae (.getMessage ex)))))))
+      (invert#t m)))

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray_double.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray_double.clj
@@ -8,7 +8,6 @@
             [clojure.walk :as w]
             [clojure.core.matrix.impl.ndarray :refer :all]
             [clojure.core.matrix.utils :refer :all]
-            [clojure.core.matrix.impl.ndarray-macro :refer :all])
-  (:import [clojure.lang ExceptionInfo]))
+            [clojure.core.matrix.impl.ndarray-macro :refer :all]))
 
 (magic/spit-code :double)

--- a/src/main/clojure/clojure/core/matrix/impl/ndarray_double.clj
+++ b/src/main/clojure/clojure/core/matrix/impl/ndarray_double.clj
@@ -8,6 +8,7 @@
             [clojure.walk :as w]
             [clojure.core.matrix.impl.ndarray :refer :all]
             [clojure.core.matrix.utils :refer :all]
-            [clojure.core.matrix.impl.ndarray-macro :refer :all]))
+            [clojure.core.matrix.impl.ndarray-macro :refer :all])
+  (:import [clojure.lang ExceptionInfo]))
 
 (magic/spit-code :double)

--- a/src/main/clojure/clojure/core/matrix/protocols.clj
+++ b/src/main/clojure/clojure/core/matrix/protocols.clj
@@ -757,7 +757,7 @@
      to compute determinants.
      Must throw an error if the matrix is not square (i.e. different number of rows and columns)")
   (inverse [m]
-    "Returns the invese of a matrix. Should return nil if m is not invertible."))
+    "Returns the inverse of a matrix. Should return nil if m is not invertible."))
 
 (defprotocol PNegation
   (negate [m]

--- a/src/test/clojure/clojure/core/matrix/test_ndarray_implementation.clj
+++ b/src/test/clojure/clojure/core/matrix/test_ndarray_implementation.clj
@@ -212,7 +212,11 @@
 
 (deftest test-inverse
   (is (e== (invert-double (ndarray-double [[0 1 0] [1 1 0] [1 -1 -1]])) 
-           (ndarray-double [[-1.0,1.0,0.0],[1.0,-0.0,0.0],[-2.0,1.0,-1.0]]))))
+           (ndarray-double [[-1.0,1.0,0.0],[1.0,-0.0,0.0],[-2.0,1.0,-1.0]])))
+  (is (nil? (inverse (matrix :ndarray-double [[0 0 1] [1 1 0] [1 1 1]])))))
+
+(deftest test-determinant
+  (is (== 0.0 (det (matrix :ndarray-double [[0 0 1] [1 1 0] [1 1 1]])))))
 
 (deftest ndarray-test
   (ct/test-ndarray-implementation (empty-ndarray [3 3])))


### PR DESCRIPTION
ndarray-double's inverse and determinant were calling `lu-decompose!`, which throws IllegalArgumentExceptions on singular input.

This change moves the code to an internal ns use fn `_lu-decompose!` and now throws ex-info with `{:cause ::singular}`.
The functions `lu-decompose!`, `determinant` and `inverse` now call the internal `_lu-decompose!` in a try block and return the appropriate return values (nil for inverse and lu, 0 for determinant) when ex-info is caught with :cause ::singular

There were also two small tests added that are passing from this change
