### PR TITLE
 added selection, utils to codox path

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -79,8 +79,9 @@
                        clojure.core.matrix.protocols
                        clojure.core.matrix.random
                        clojure.core.matrix.implementations
-                       clojure.core.matrix.select
-                       clojure.core.matrix.stats]
+                       clojure.core.matrix.selection
+                       clojure.core.matrix.stats
+                       clojure.core.matrix.utils]
           :src-dir-uri "https://github.com/mikera/core.matrix/blob/master/"
           :src-linenum-anchor-prefix "L"})
 


### PR DESCRIPTION
The select ns was renamed to selection in the past. Updating codox to accept the new path
