### PR TITLE
Formatting of titles in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Neanderthal implementation reference
 - Weka implementation reference
+
 ### Fixed
 - Fixed persistent vector coercion issue #302
 
 ## [0.56.0] - 2016-10-03
 ### Changed
 - Improvements to dataset representations. Should be non-breaking if user did not rely on implementation details :-)
+
 ### Added
 - Add dataset/emap-columns function
 - Allow printing of column names in pprint functionality
+
 ### Fixed
 - Improve docstrings
 - Improved implementations for double[][] arrays
@@ -26,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add filter-slices API function
 - Implement generalised N-dimensional transpose functionality
 - Improve broadcasting docs and default implementation
+
 ### Fixed
 - Improve docstrings
 - Fix for default mutable matrix construction
@@ -42,6 +46,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.53.0] - 2016-08-12
 ### Added
 - References to ND4J implementation
+
 ### Fixed
 - Reinstate c.c.m.utils/error? for backwards compatibility
 


### PR DESCRIPTION
Titles need empty lines after bullet lists to render correctly.