### PR TITLE
Changed svd docstring to reflect return value

### DIFF
--- a/src/main/clojure/clojure/core/matrix/linear.cljc
+++ b/src/main/clojure/clojure/core/matrix/linear.cljc
@@ -94,7 +94,7 @@
 
    Where
      - U is an unitary matrix
-     - S is a diagonal matrix whose elements are the singular values of the original matrix
+     - S is a sequence whose elements are the singular values of the original matrix
      - V* is an unitary matrix
 
    If :return parameter is specified in options map, it returns only specified keys.


### PR DESCRIPTION
Vectorz and Clatrix value of `svd`'s `:S` key is a sequence of singular values.  Old docstring said it was a matrix.  New docstring corrects that.