### PR TITLE
Port code to cljs fixing warnings related to numeric and object types.

### DIFF
--- a/src/main/clojure/clojure/core/matrix.cljc
+++ b/src/main/clojure/clojure/core/matrix.cljc
@@ -268,7 +268,7 @@
   ([data]
     (try (or (mp/mutable-matrix data)
             (mutable (implementation-check) data))
-      (catch Throwable t ;; catch error in array construction, attempt to use a default implementation
+      (catch #?(:clj Throwable :cljs js/object) t ;; catch error in array construction, attempt to use a default implementation
         (default/construct-mutable-matrix data))))
   ([implementation data]
     (let [imp (implementation-check implementation)

--- a/src/main/clojure/clojure/core/matrix/impl/common.cljc
+++ b/src/main/clojure/clojure/core/matrix/impl/common.cljc
@@ -52,7 +52,8 @@
     (or (mp/construct-matrix impl data)
         (try 
           (mp/construct-matrix mi/*matrix-implementation* data)
-          (catch ClassCastException t nil)) ;; fix for element type not handled
+          (catch #?(:clj ClassCastException
+                   :cljs js/object) t nil)) ;; fix for element type not handled
         (mp/construct-matrix [] data))))
 
 (defn mapmatrix

--- a/src/main/clojure/clojure/core/matrix/impl/dataset.cljc
+++ b/src/main/clojure/clojure/core/matrix/impl/dataset.cljc
@@ -328,7 +328,7 @@
         (mapv #(mp/get-1d % ix) cols))))
 
 (extend-protocol mp/PColumnIndex
-  #?(:clj Object :cljs js/Object)
+  #?(:clj Object :cljs object)
     (column-index [ds column-name]
       (when-let [cnames (mp/column-names ds)]
         (let [cnames ^IPersistentVector (vec cnames)]
@@ -363,7 +363,7 @@
         (->> (map #(nth row-maps %) rows)
              (dataset-from-row-maps col-names))
         (catch
-            #?(:clj Exception :cljs js/Object) e
+            #?(:clj Exception :cljs js/object) e
           (let [c (long (count (mp/get-rows ds)))
                 out-of-range (filter #(>= (long %) c) rows)]
             (if (> (long (count out-of-range)) 0)
@@ -430,7 +430,7 @@
                     (mp/get-columns ds))))
   
     #?(:clj Object
-       :cljs js/Object)
+       :cljs object)
        (row-maps [ds]
          (if-let [col-names (mp/column-names ds)]
            (mapv #(zipmap col-names (mp/element-seq %))

--- a/src/main/clojure/clojure/core/matrix/impl/defaults.cljc
+++ b/src/main/clojure/clojure/core/matrix/impl/defaults.cljc
@@ -815,7 +815,7 @@
       (loop [i (long 0)
              pairs (seq pairs)]
         (when (< i n)
-          (aset dest (first (first pairs)) (Long/valueOf i))
+          (aset dest (first (first pairs)) #?(:clj (Long/valueOf i) :cljs i))
           (recur (inc i)
                  (next pairs))))
       (vec dest))))
@@ -1193,7 +1193,7 @@
 ;; general transformation of a vector
 (extend-protocol mp/PVectorTransform
   #?(:clj clojure.lang.IFn
-     :cljs cljs.core.IFn)
+     :cljs cljs.core/IFn)
     (vector-transform [m a]
       (if
         (vector? m) (mp/matrix-multiply m a)
@@ -1997,7 +1997,7 @@
   #?(:clj Object :cljs object)
     (reshape-view [m shape]
       (if (mp/is-mutable? m)
-        (TODO "reshape-view not supported on mutable array of type: " (class m))
+        (TODO "reshape-view not supported on mutable array of type: " (#?(:clj class :cljs type) m))
         (mp/reshape m shape))))
 
 (extend-protocol mp/PCoercion

--- a/src/main/clojure/clojure/core/matrix/stats.cljc
+++ b/src/main/clojure/clojure/core/matrix/stats.cljc
@@ -119,7 +119,10 @@
              ydiff (m/sub actl ymean)
              tss (double (m/esum (m/square ydiff)))
              res (- 1.0 (/ sse tss))]
-         (if (or  (= res Double/NEGATIVE_INFINITY) (Float/isNaN res))
+         (if (or  (= res #?(:clj Double/NEGATIVE_INFINITY
+                           :cljs js/Number.NEGATIVE_INFINITY))
+                  (#?(:clj Float/isNaN
+                     :cljs js/Number.isNaN) res))
            nil res))
        nil))))
 


### PR DESCRIPTION
This fixes a bunch of unported ClojureScript call-sites that clutter my build logs with warnings. I still get errors from the `doseq-indexed`, but couldn't figure out yet why it is not expanding correctly. I would suggest using https://github.com/cgrand/macrovich for macro definition and expansion, as it would allow `core.matrix` also to be loadable in self-hosted ClojureScript. I am not sure whether this is currently possible(?). 