### PR TITLE
Fixed a space missing in error message when using select-columns

### DIFF
--- a/src/main/clojure/clojure/core/matrix/impl/dataset.cljc
+++ b/src/main/clojure/clojure/core/matrix/impl/dataset.cljc
@@ -349,7 +349,7 @@
       (let [^List all-col-names (get-column-names ds)
             indices (mapv (fn [name]
                             (let [ix (.indexOf all-col-names name)]
-                              (when (== -1 ix) (error "Column name " name "not found in Dataset"))
+                              (when (== -1 ix) (error "Column name " name " not found in Dataset"))
                               ix))
                           col-names)
             nthfn (fn[ i j] #?(:clj (.nth ^IPersistentVector i j)

--- a/src/test/clojure/clojure/core/matrix/test_dataset.cljc
+++ b/src/test/clojure/clojure/core/matrix/test_dataset.cljc
@@ -97,6 +97,9 @@
     (is (= (select-columns ds1 [:a :b])
            (dataset [:a :b] (matrix [[1 4] [2 5] [3 6] [4 7]]))))
     (is (= (select-columns ds2 [:a :b]) (dataset [:a :b] [])))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo 
+                          #"Column name :not-there not found in Dataset"
+                          (select-columns ds1 [:not-there]))) 
     (is (= (remove-columns ds1 [:a :b])
            (dataset [:c] (matrix [[9] [9] [9] [9]]))))))
 


### PR DESCRIPTION
When using select-columns on a Dataset where the column does not exist, there was missing a space in the error message that got thrown. 