### PR TITLE
Fixed cljs require-macros bug

### DIFF
--- a/src/main/clojure/clojure/core/matrix/utils.cljc
+++ b/src/main/clojure/clojure/core/matrix/utils.cljc
@@ -4,8 +4,9 @@
   #?@(:clj [(:require [clojure.reflect :as r])
             (:import [java.util Arrays]
                      [clojure.lang IPersistentVector])])
-  (#?(:clj :require :cljs :require-macros)
-           [clojure.core.matrix.macros :refer [TODO is-long-array?]]))
+  #?(:clj  (:require [clojure.core.matrix.macros :refer [TODO is-long-array?]])
+     :cljs (:require-macros [clojure.core.matrix.macros :refer [TODO]]
+                            [clojure.core.matrix.utils :refer [doseq-indexed]])))
 
 ;; Some of these are copies of methods from the library
 ;;   https://github.com/mikera/clojure-utils


### PR DESCRIPTION
Code was failing to compile in ClojureScript because `doseq-indexed` was not required. This seemed to resolve the issue.