### PR TITLE
Docker dev environment for easy repeatable builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ To build the Clojurescript unit tests you can run:
     lein with-profile +cljs cljsbuild once
 
 and then load resources/public/test.html in a browser to run the tests.
+### Docker
+A Docker setup is available for quick reproducable envivironment.
+
+#### Sample Commands
+
+To build the dev environment image. This is currently based on `clojure:openjdk-11-lein-buster` image.
+
+    `docker build -f ./docker/Dockerfile . -t core.matrix-dev`
+
+To run the build after the dev image is ready
+
+    `docker run --rm core.matrix-dev`
+
+To run interactive bash shell for adhoc build commands
+
+    `docker run -it --entrypoint bash core.matrix-dev`
+
 
 ### Status
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM clojure:openjdk-11-lein-buster
+
+RUN apt-get update -qq
+RUN apt-get install libquadmath0 -qq
+WORKDIR /tmp
+RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-6/gcc-6-base_6.4.0-17ubuntu1_amd64.deb
+RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-6/libgfortran3_6.4.0-17ubuntu1_amd64.deb
+RUN dpkg -i gcc-6-base_6.4.0-17ubuntu1_amd64.deb
+RUN dpkg -i libgfortran3_6.4.0-17ubuntu1_amd64.deb
+
+WORKDIR /usr/src/core.matrix
+
+# Dependencies
+COPY project.clj .
+RUN lein deps
+
+COPY . .
+CMD ["/usr/local/bin/lein", "test"]

--- a/project.clj
+++ b/project.clj
@@ -33,13 +33,15 @@
                              [criterium/criterium "0.4.3"]
                              [org.clojure/clojurescript "1.9.908"]
                              [org.clojure/tools.macro "0.1.5"]
-                             [org.clojure/test.check "0.9.0"]]}
+                             [org.clojure/test.check "0.9.0"]
+                             [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]]}
 
              :cljs
              {:dependencies [[org.clojure/clojurescript "1.9.908"]
                              [thinktopic/aljabr "0.1.0-SNAPSHOT" :exclusions [net.mikera/core.matrix]]
                              [figwheel-sidecar "0.5.8"]
                              [com.cemerick/piggieback "0.2.1"]
+                             [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]
                              ]
               :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
               :plugins [[lein-figwheel "0.5.13"]


### PR DESCRIPTION
I found it hard to setup dependencies on my local machine and hence wanted an easier environment before making any further changes.
- Currently this only includes setup for jdk11. 
- I had to add `javax.xml.bind/jaxb-api`
- clojurescript build seems to not work. Is this supposed to work? If so what versions does this work for?

would be happy to make changes based on this.