### PR TITLE
Removing unused usages of clojure.reflect in order to remove this dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM clojure:openjdk-11-lein-buster
 
 RUN apt-get update -qq
-RUN apt-get install libquadmath0 -qq
+RUN apt-get install libquadmath0 maven -qq
 WORKDIR /tmp
 RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-6/gcc-6-base_6.4.0-17ubuntu1_amd64.deb
 RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-6/libgfortran3_6.4.0-17ubuntu1_amd64.deb

--- a/docker/Dockerfile.jdk8
+++ b/docker/Dockerfile.jdk8
@@ -1,0 +1,18 @@
+FROM clojure:openjdk-8-lein-buster
+
+RUN apt-get update -qq
+RUN apt-get install libquadmath0 -qq
+WORKDIR /tmp
+RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-6/gcc-6-base_6.4.0-17ubuntu1_amd64.deb
+RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-6/libgfortran3_6.4.0-17ubuntu1_amd64.deb
+RUN dpkg -i gcc-6-base_6.4.0-17ubuntu1_amd64.deb
+RUN dpkg -i libgfortran3_6.4.0-17ubuntu1_amd64.deb
+
+WORKDIR /usr/src/core.matrix
+
+# Dependencies
+COPY project.clj .
+RUN lein deps
+
+COPY . .
+CMD ["/usr/local/bin/lein", "test"]

--- a/docker/Dockerfile.jdk8
+++ b/docker/Dockerfile.jdk8
@@ -1,7 +1,7 @@
 FROM clojure:openjdk-8-lein-buster
 
 RUN apt-get update -qq
-RUN apt-get install libquadmath0 -qq
+RUN apt-get install libquadmath0 maven -qq
 WORKDIR /tmp
 RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-6/gcc-6-base_6.4.0-17ubuntu1_amd64.deb
 RUN wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-6/libgfortran3_6.4.0-17ubuntu1_amd64.deb

--- a/src/dev/clojure/clojure/core/matrix/docgen/implementations.clj
+++ b/src/dev/clojure/clojure/core/matrix/docgen/implementations.clj
@@ -68,12 +68,3 @@
     [:div.pure-g
      [:div.pure-u-1 header]
      [:div.pure-u-1 table]]]))
-
-(defn generate
-  []
-  (let [impl-objs (c/get-impl-objs)
-        protos (c/extract-implementations (u/extract-protocols) impl-objs)
-        git-hash (c/get-git-hash)
-        header (render-header git-hash)
-        table (render-table impl-objs protos git-hash)]
-    (render-page header table)))

--- a/src/main/clojure/clojure/core/matrix/impl/common.cljc
+++ b/src/main/clojure/clojure/core/matrix/impl/common.cljc
@@ -20,22 +20,6 @@
 
 #?(:clj (do
 
-(defn find-implementers
-  "Returns a set of implementation names of implementations that
-   support provided protocol"
-  [protocol impl-objs]
-  (->> impl-objs
-       (filter #(->> % :obj class (u/extends-deep? protocol)))
-       (map :name)
-       (into #{})))
-
-(defn extract-implementations
-  "Returns a a sequence of protocol maps augmented with :implemented-by key
-   that contains a set of names of supporting implementations"
-  [protocols impl-objs]
-  (for [proto protocols]
-    (assoc proto :implemented-by (find-implementers proto impl-objs))))
-
 (defn get-git-hash
   "Returns current revision's git hash"
   []

--- a/src/main/clojure/clojure/core/matrix/utils.cljc
+++ b/src/main/clojure/clojure/core/matrix/utils.cljc
@@ -1,8 +1,7 @@
 (ns clojure.core.matrix.utils
   "Namespace for core.matrix utilities. Intended mainly for library and tool writers."
   (:refer-clojure :exclude [update])
-  #?@(:clj [(:require [clojure.reflect :as r])
-            (:import [java.util Arrays]
+  #?@(:clj [(:import [java.util Arrays]
                      [clojure.lang IPersistentVector])])
   #?(:clj  (:require [clojure.core.matrix.macros :refer [TODO is-long-array?]])
      :cljs (:require-macros [clojure.core.matrix.macros :refer [TODO]]
@@ -226,26 +225,6 @@
 
 ;; utilities for protocol introspection
 
-#?(:clj
-(defn extends-deep?
-  "This functions differs from ordinary `extends?` by using `extends?`
-   on all ancestors of given type instead of just type itself. It also
-   skips `java.lang.Object` that serves as a default implementation
-   for all protocols"
-  [proto cls]
-  ;; Here we need a special case to avoid reflecting on primitive type
-  ;; (it will cause an exception)
-  (if (= (Class/forName "[D") cls)
-    (extends? proto cls)
-    (let [bases (-> cls (r/type-reflect :ancestors true) :ancestors)]
-      (->> bases
-           (filter (complement #{'Object 'java.lang.Object}))
-           (map resolve)
-           (cons cls)
-           (map (partial extends? proto))
-           (some true?)))))
-)
-
 (defn protocol?
   "Returns true if an argument is a protocol'"
   [p]
@@ -271,15 +250,6 @@
       (map enhance-protocol-kv)
       (sort-by :line))))
 
-(defn unimplemented
-  "Identifies which protocols are unimplemented for a given array object.
-
-   Unimplemented protocols will fall back to the default implementation (for java.lang.Object) which
-   is likely to be slower than a specialised implementation."
-  [m]
-  (let [protocols (extract-protocols)
-        m (if (class? m) m (class m))]
-    (map :name (filter #(not (#?(:clj extends-deep? :cljs satisfies?) % m)) protocols))))
 ))
 
 (defn update-indexed [xs idxs f]

--- a/src/test/clojure/clojure/core/matrix/test_utils.clj
+++ b/src/test/clojure/clojure/core/matrix/test_utils.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [vector?])
   (:require [clojure.core.matrix.protocols :as mp]
             [clojure.core.matrix :refer :all]
-            [clojure.core.matrix.utils :refer [extends-deep? extract-protocols]]
+            [clojure.core.matrix.utils :refer [extract-protocols]]
             [clojure.test :refer :all])
   (:import [clojure.lang PersistentVector]
            [mikera.vectorz Vector]))
@@ -12,10 +12,6 @@
 (deftest test-long-array
   (is (= (type (long-array 0)) (type (long-array nil))))
   (is (= (count (long-array 0)) (count (long-array nil)))))
-
-(deftest test-protocol-extension
-  (is (extends-deep? mp/PImplementation PersistentVector))
-  (is (extends-deep? mp/PImplementation Vector)))
 
 ;; this tests that all protocols have a default implementation for java.lang.Object
 ;; (except for specified known exceptions


### PR DESCRIPTION
As discussed in Issue #349, I am removing various reflection methods which don't appear to be used anywhere.
PR is a simple removal of unused code scoped to the ones that are linked to usage of `clojure.reflect`
