### PR TITLE
Fix docstring, correcting order of arguments

### DIFF
--- a/src/main/clojure/clojure/core/matrix.cljc
+++ b/src/main/clojure/clojure/core/matrix.cljc
@@ -1876,7 +1876,7 @@ elements not-equal to the argument are 0.
 (defn distance
   "Calculates the euclidean distance between two numerical vectors, as a single numerical scalar value.
 
-   This is equivalent to (norm 2 (sub a b)) but may be optimised by the underlying implementation."
+   This is equivalent to (norm (sub a b) 2) but may be optimised by the underlying implementation."
   ([a b]
     (mp/distance a b)))
 


### PR DESCRIPTION
The order of arguments for norm is wrong in the example docstring for `distance`.
Correct usage, via https://github.com/mikera/core.matrix/blob/develop/src/main/clojure/clojure/core/matrix/linear.cljc#L20

```clojure
(defn norm
  ([m] (norm m 2))
  ([m p] (mp/norm m p)))
```